### PR TITLE
Bump the version of the elements when a scene is loaded from a blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,25 @@
 </p>
 <p align="center"><i>Enabling society to collaborate. Building a better future, together.</i></p>
 # Alkemio fork of Excalidraw v0.17.0
-- Upgraded from Excalidraw v0.16.1 to v0.17.0
-  - Procedure is very similar to previous versions below:
-  ```
+
+### Upgrade procedure
+```
   git fetch --tags upstream
   git checkout 0.16.1-alkemio-1
   git merge v0.17.0
   git push --set-upstream origin 0.17.0-alkemio-1
-  ```
-- Applied the new styles of the buttons to Alkemio's ZoomToFit added button.
+```
+
+### List of differences with standard Excalidraw
+- ZoomToFit feature exposed through the external API
+- Added ZoomToFit button to the zoom toolbar
+- Added ZoomToFit flag to initialData to fit items on load
 - Modified the paste functionality to avoid pasting elements (such as images) as JSON when editing text.
+- Added `hideLibraryButton` to the appState to be able to hide the button from outside.
+- Changed the toolbar Lock button behavior. Now it locks/unlocks elements instead of the tool in use
+- Changed the load from file behavior to fix multi-user collaboration bug. Now elements loaded will have version number > currentScene version number
 
-### For testing you can link the new package from the local client
-
+### Testing locally inside Alkemio client
 ```
 npm link
 cd ../client-web
@@ -23,7 +29,7 @@ npm link @alkemio/excalidraw --save
 ```
 
 ### Build and publish the new npm package:
-
+Find in json files any `'alkemio-XX'` and set the version you want to publish
 ```
 yarn
 cd src/packages/excalidraw
@@ -32,20 +38,23 @@ yarn build:umd
 yarn pack
 yarn publish
 ```
-# Alkemio fork of Excalidraw v0.17.0-alkemio-4
+
+## Change Log
+### Alkemio fork of Excalidraw v0.17.0-alkemio-5
+
+### Alkemio fork of Excalidraw v0.17.0-alkemio-4
 - Added `hideLibraryButton` to the appState to be able to hide the button from outside.
 - Changed the toolbar Lock button behavior. Now it locks/unlocks elements instead of the tool in use
 
-# Alkemio fork of Excalidraw v0.17.0-alkemio-3-beta
+### Alkemio fork of Excalidraw v0.17.0-alkemio-3-beta
 - Changed behavior. Pasting elements is better handled and now it doesn't end up as a big text node with JSON inside.
 
-
-# Alkemio fork of Excalidraw v0.17.0
-
+### Alkemio fork of Excalidraw v0.17.0
 - Upgraded from Excalidraw v0.16.1 to v0.17.0
+- Applied the new styles of the buttons to Alkemio's ZoomToFit added button.
 
 
-# Alkemio fork of Excalidraw v0.16.1
+### Alkemio fork of Excalidraw v0.16.1
 
 - Upgraded from Excalidraw v0.15.2 to v0.16.1
 
@@ -69,15 +78,15 @@ yarn publish
 
 - Fixed merge conflicts and a small issue with the zoomToFit icon, they have added a function with the same name.
 
-# Alkemio fork of Excalidraw v0.15.2
+### Alkemio fork of Excalidraw v0.15.2
 
-### Modifications:
+#### Modifications:
 
 - ZoomToFit feature exposed through the external API
 - Added ZoomToFit button to the zoom toolbar
 - Added ZoomToFit flag to initialData to fit items on load
 
-### Development guidelines
+#### Development guidelines
 
 - First of all, Excalidraw uses yarn as package manager, so first thing to do is make sure you have yarn installed in your system. `npm install --global yarn`.
 - Clone the repository to a local folder: `git clone git@github.com:alkem-io/excalidraw.git` and create a feature branch to store your work.
@@ -89,7 +98,7 @@ yarn publish
 - Once is merged to `develop`, checkout `develop` branch and see below how to build and publish the package to NPM repository.
 - Make sure you switch back the package in your client-web to use the published @alkemio/excalidraw package's new version instead of the old one or the linked one if you changed it.
 
-### Build and publish a new npm package:
+#### Build and publish a new npm package:
 
 ```
 yarn

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ yarn publish
 
 ## Change Log
 ### Alkemio fork of Excalidraw v0.17.0-alkemio-5
+- Changed the load from file behavior to fix multi-user collaboration bug. Now elements loaded will have version number > currentScene version number
+- WARNING: This is a test, and it is not going to work, further changes are needed.
 
 ### Alkemio fork of Excalidraw v0.17.0-alkemio-4
 - Added `hideLibraryButton` to the appState to be able to hide the button from outside.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "homepage": "https://github.com/alkem-io/excalidraw",
   "name": "@alkemio/excalidraw",
-  "version": "0.17.0-alkemio-4",
+  "version": "0.17.0-alkemio-5",
   "prettier": "@excalidraw/prettier-config",
   "private": false,
   "scripts": {

--- a/src/data/restore.ts
+++ b/src/data/restore.ts
@@ -16,6 +16,7 @@ import { ImportedDataState, LegacyAppState } from "./types";
 import {
   getNonDeletedElements,
   getNormalizedDimensions,
+  getSceneVersion,
   isInvisiblySmallElement,
   refreshTextDimensions,
 } from "../element";
@@ -422,6 +423,7 @@ export const restoreElements = (
   // used to detect duplicate top-level element ids
   const existingIds = new Set<string>();
   const localElementsMap = localElements ? arrayToMap(localElements) : null;
+  const sceneVersion = getSceneVersion(localElements ?? []);
   const restoredElements = (elements || []).reduce((elements, element) => {
     // filtering out selection, which is legacy, no longer kept in elements,
     // and causing issues if retained
@@ -434,6 +436,8 @@ export const restoreElements = (
         const localElement = localElementsMap?.get(element.id);
         if (localElement && localElement.version > migratedElement.version) {
           migratedElement = bumpVersion(migratedElement, localElement.version);
+        } else {
+          migratedElement = bumpVersion(migratedElement, sceneVersion);
         }
         if (existingIds.has(migratedElement.id)) {
           migratedElement = { ...migratedElement, id: randomId() };

--- a/src/packages/excalidraw/package.json
+++ b/src/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/excalidraw",
-  "version": "0.17.0-alkemio-4",
+  "version": "0.17.0-alkemio-5",
   "main": "main.js",
   "types": "types/packages/excalidraw/index.d.ts",
   "files": [


### PR DESCRIPTION
PENDING:
- Update the destination branch. This should go to develop
- An alkemio-5 package has been released to npmjs but it will not work. See [client / #6977](https://github.com/alkem-io/client-web/pull/6977) these changes are not enough