### PR TITLE
Replaced enum GridLineColor with a const object

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ npm link @alkemio/excalidraw --save
 Find in json files any `'alkemio-XX'` and set the version you want to publish
 ```
 yarn
-cd src/packages/excalidraw
+cd packages/excalidraw
 yarn install
-yarn build:umd
+yarn build:esm
 yarn pack
 yarn publish
 ```

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/excalidraw",
-  "version": "0.17.1-alkemio-5",
+  "version": "0.17.1-alkemio-7",
   "main": "./dist/prod/index.js",
   "type": "module",
   "module": "./dist/prod/index.js",

--- a/packages/excalidraw/renderer/staticScene.ts
+++ b/packages/excalidraw/renderer/staticScene.ts
@@ -42,10 +42,10 @@ const strokeGrid = (
 ) => {
   const BOLD_LINE_FREQUENCY = 5;
 
-  enum GridLineColor {
-    Bold = "#cccccc",
-    Regular = "#e5e5e5",
-  }
+  const GridLineColor2 = {
+    Bold: "#cccccc",
+    Regular: "#e5e5e5",
+  } as const;
 
   const offsetX =
     -Math.round(zoom.value / gridSize) * gridSize + (scrollX % gridSize);
@@ -65,7 +65,7 @@ const strokeGrid = (
       Math.round(x - scrollX) % (BOLD_LINE_FREQUENCY * gridSize) === 0;
     context.beginPath();
     context.setLineDash(isBold ? [] : lineDash);
-    context.strokeStyle = isBold ? GridLineColor.Bold : GridLineColor.Regular;
+    context.strokeStyle = isBold ? GridLineColor2.Bold : GridLineColor2.Regular;
     context.moveTo(x, offsetY - gridSize);
     context.lineTo(x, offsetY + height + gridSize * 2);
     context.stroke();
@@ -75,7 +75,7 @@ const strokeGrid = (
       Math.round(y - scrollY) % (BOLD_LINE_FREQUENCY * gridSize) === 0;
     context.beginPath();
     context.setLineDash(isBold ? [] : lineDash);
-    context.strokeStyle = isBold ? GridLineColor.Bold : GridLineColor.Regular;
+    context.strokeStyle = isBold ? GridLineColor2.Bold : GridLineColor2.Regular;
     context.moveTo(offsetX - gridSize, y);
     context.lineTo(offsetX + width + gridSize * 2, y);
     context.stroke();


### PR DESCRIPTION
```
enum GridLineColor {
    Bold = "#cccccc",
    Regular = "#e5e5e5",
 }
```
Is building to: 
```
(function (GridLineColor) {
GridLineColor["Bold"] = "#cccccc";    GridLineColor["Regular"] = "#e5e5e5";})(GridLineColor || (GridLineColor = {}))
```
Which minified, is:
```
 (p => (p.Bold = "#cccccc",
        p.Regular = "#e5e5e5"))(void 0 || (s = {}));
```

And that ends up in a weird JS error in the browser console:
![image](https://github.com/user-attachments/assets/8973ef6e-4e0f-4ad2-a49e-2d97baecd384)

We have replaced that enum with just a plain Javascript object:
```
  const GridLineColor2 = {
    Bold: "#cccccc",
    Regular: "#e5e5e5",
  } as const;
```
