### PR TITLE
Load from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ yarn publish
 
 ## Change Log
 
+### Alkemio fork of Excalidraw v0.17.0-alkemio-8
+- Version bump to `0.17.1-alkemio-8`
+- `addElementsFromPasteOrLibrary` exposed to the public API
+- opening a file now inserts elements in the current scene. Does not overwrite them anymore.
+
 ### Alkemio fork of Excalidraw v0.17.0-alkemio-4
 - Added `hideLibraryButton` to the appState to be able to hide the button from outside.
 - Changed the toolbar Lock button behavior. Now it locks/unlocks elements instead of the tool in use

--- a/packages/excalidraw/actions/actionExport.tsx
+++ b/packages/excalidraw/actions/actionExport.tsx
@@ -20,6 +20,7 @@ import { Theme } from "../element/types";
 
 import "../components/ToolIcon.scss";
 import { StoreAction } from "../store";
+import {reconcileElements, RemoteExcalidrawElement} from "../data/reconcile";
 
 export const actionChangeProjectName = register({
   name: "changeProjectName",
@@ -253,14 +254,19 @@ export const actionLoadScene = register({
     try {
       const {
         elements: loadedElements,
-        appState: loadedAppState,
         files,
       } = await loadFromJSON(appState, elements);
-      return {
+
+      app.addElementsFromPasteOrLibrary({
         elements: loadedElements,
-        appState: loadedAppState,
         files,
+        position: "cursor",
+        fitToContent: true,
+      });
+
+      return {
         storeAction: StoreAction.CAPTURE,
+        replaceFiles: false,
       };
     } catch (error: any) {
       if (error?.name === "AbortError") {

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -699,6 +699,7 @@ class App extends React.Component<AppProps, AppState> {
         setCursor: this.setCursor,
         resetCursor: this.resetCursor,
         updateFrameRendering: this.updateFrameRendering,
+        addElementsFromPasteOrLibrary: this.addElementsFromPasteOrLibrary,
         toggleSidebar: this.toggleSidebar,
         onChange: (cb) => this.onChangeEmitter.on(cb),
         onPointerDown: (cb) => this.onPointerDownEmitter.on(cb),

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -522,7 +522,7 @@
       "loadFromFile": {
         "title": "Load from file",
         "button": "Load from file",
-        "description": "Loading from a file will <bold>replace your existing content</bold>.<br></br>You can back up your drawing first using one of the options below."
+        "description": "Loading from a file will <bold>insert content on top of your existing content</bold>.<br></br>You can back up your drawing first using one of the options below."
       },
       "shareableLink": {
         "title": "Load from link",

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/excalidraw",
-  "version": "0.17.1-alkemio-7",
+  "version": "0.17.1-alkemio-8",
   "main": "./dist/prod/index.js",
   "type": "module",
   "module": "./dist/prod/index.js",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -704,6 +704,7 @@ export interface ExcalidrawImperativeAPI {
    * used in conjunction with view mode (props.viewModeEnabled).
    */
   updateFrameRendering: InstanceType<typeof App>["updateFrameRendering"];
+  addElementsFromPasteOrLibrary: InstanceType<typeof App>["addElementsFromPasteOrLibrary"];
   onChange: (
     callback: (
       elements: readonly ExcalidrawElement[],


### PR DESCRIPTION
- Version bump to `0.17.1-alkemio-8`
- `addElementsFromPasteOrLibrary` exposed to the public API
- opening a file now inserts elements in the current scene. Does not overwrite them anymore.