### PR TITLE
feat(repo): WS-B2 — per-property Yjs whiteboard binding

### DIFF
--- a/.github/workflows/release-alkemio.yml
+++ b/.github/workflows/release-alkemio.yml
@@ -51,11 +51,18 @@ jobs:
 
       # --- Release path: tag v* -> publish both packages to npmjs (OIDC + provenance) ---
 
+      # Build BOTH packages before publishing either one, so a build failure does not
+      # leave one package published and the other missing from the registry.
+      - name: Build packages for release (Tag)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          yarn --cwd packages/excalidraw build:esm
+          yarn --cwd packages/yjs-binding build:esm
+
       - name: Publish @alkemio/excalidraw to npmjs (Tag)
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         working-directory: packages/excalidraw
         run: |
-          yarn build:esm
           VERSION=$(node -p "require('./package.json').version")
           echo "Publishing @alkemio/excalidraw@${VERSION} to npmjs"
           npm publish --access public --provenance --tag latest
@@ -73,7 +80,6 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         working-directory: packages/yjs-binding
         run: |
-          yarn build:esm
           VERSION=$(node -p "require('./package.json').version")
           echo "Publishing @alkemio/excalidraw-yjs-binding@${VERSION} to npmjs"
           npm publish --access public --provenance --tag latest

--- a/.github/workflows/release-alkemio.yml
+++ b/.github/workflows/release-alkemio.yml
@@ -1,37 +1,125 @@
 name: Release Alkemio package
+
+# Dual-registry publish, modelled on matrix-adapter's publish-lib.yml:
+#   - Tag push (v*)        -> publish BOTH packages to npmjs (OIDC + provenance, no token)
+#   - Pull request / manual -> publish a pkg.pr.new preview for BOTH packages (PR comment)
+#
+# Versioning note: @alkemio/excalidraw uses a hand-maintained version string
+# (e.g. 0.18.0-<sha>-alkemio-N) that is committed into packages/excalidraw/package.json,
+# and @alkemio/excalidraw-yjs-binding locksteps at the same base (0.18.0). These are NOT
+# derived from the git tag — so, unlike matrix-adapter, this workflow does NOT run
+# `npm version` from the tag. It publishes whatever version is committed in each
+# package.json. Bump the version by committing the package.json change before tagging.
+
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'packages/excalidraw/**'
+      - 'packages/yjs-binding/**'
+  workflow_dispatch:
+
 permissions:
-  id-token: write # Required for OIDC
   contents: read
+  pull-requests: write  # Required for pkg-pr-new PR comments
+  id-token: write       # Required for npm provenance / trusted publishing
 
 jobs:
-  Auto-release-alkemio-package:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 2
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
-          registry-url: "https://registry.npmjs.org"
+          node-version: '22.14.0'
+          # Only point at npmjs on a tag publish; previews use pkg.pr.new and need no registry.
+          registry-url: ${{ startsWith(github.ref, 'refs/tags/v') && 'https://registry.npmjs.org' || '' }}
+
+      # Node 22.14.0 bundles npm 10.x; OIDC trusted publishing needs npm >= 11.5.1.
+      # (matrix-adapter runs on node 24 which already ships npm 11+, so it omits this.)
       - name: Upgrade npm for trusted publishing
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: npm install -g npm@latest
-      - name: Auto release
+
+      - name: Install workspace dependencies
+        run: yarn install
+
+      # --- Release path: tag v* -> publish both packages to npmjs (OIDC + provenance) ---
+
+      - name: Publish @alkemio/excalidraw to npmjs (Tag)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        working-directory: packages/excalidraw
         run: |
-          yarn
-          cd packages/excalidraw
-          yarn install
           yarn build:esm
-          yarn pack --filename package.tgz
-          npm publish package.tgz --access public --tag latest
-      - name: Auto release yjs-binding
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Publishing @alkemio/excalidraw@${VERSION} to npmjs"
+          npm publish --access public --provenance --tag latest
+          echo "## 📦 Published to npmjs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** \`@alkemio/excalidraw@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "npm i @alkemio/excalidraw@${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View on npmjs](https://www.npmjs.com/package/@alkemio/excalidraw/v/${VERSION})" >> $GITHUB_STEP_SUMMARY
+
+      - name: Publish @alkemio/excalidraw-yjs-binding to npmjs (Tag)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        working-directory: packages/yjs-binding
         run: |
-          cd packages/yjs-binding
-          yarn install
           yarn build:esm
-          yarn pack --filename package.tgz
-          npm publish package.tgz --access public --tag latest
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Publishing @alkemio/excalidraw-yjs-binding@${VERSION} to npmjs"
+          npm publish --access public --provenance --tag latest
+          echo "## 📦 Published to npmjs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** \`@alkemio/excalidraw-yjs-binding@${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "npm i @alkemio/excalidraw-yjs-binding@${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View on npmjs](https://www.npmjs.com/package/@alkemio/excalidraw-yjs-binding/v/${VERSION})" >> $GITHUB_STEP_SUMMARY
+
+      # --- PR / manual path: non-tag -> pkg.pr.new preview for both packages ---
+
+      - name: Build packages for preview (PR/Manual)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          yarn --cwd packages/excalidraw build:esm
+          yarn --cwd packages/yjs-binding build:esm
+
+      - name: Publish preview to pkg.pr.new (PR/Manual, pinned v0.0.65)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          set +e
+          OUTPUT=$(npx pkg-pr-new@0.0.65 publish --comment=update ./packages/excalidraw ./packages/yjs-binding 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          URLS=$(echo "$OUTPUT" | grep -oE 'https://pkg\.pr\.new/[^ ]+')
+
+          if [ $STATUS -eq 0 ] && [ -n "$URLS" ]; then
+            echo "## 📦 Published preview to pkg.pr.new" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**SHA:** \`${GITHUB_SHA}\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            while IFS= read -r URL; do
+              echo "npm i ${URL}" >> $GITHUB_STEP_SUMMARY
+            done <<< "$URLS"
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## ⚠️ Preview publish failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            exit $STATUS
+          fi

--- a/.github/workflows/release-alkemio.yml
+++ b/.github/workflows/release-alkemio.yml
@@ -28,3 +28,10 @@ jobs:
           yarn build:esm
           yarn pack --filename package.tgz
           npm publish package.tgz --access public --tag latest
+      - name: Auto release yjs-binding
+        run: |
+          cd packages/yjs-binding
+          yarn install
+          yarn build:esm
+          yarn pack --filename package.tgz
+          npm publish package.tgz --access public --tag latest

--- a/.github/workflows/release-alkemio.yml
+++ b/.github/workflows/release-alkemio.yml
@@ -14,17 +14,17 @@ name: Release Alkemio package
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     paths:
-      - 'packages/excalidraw/**'
-      - 'packages/yjs-binding/**'
+      - "packages/excalidraw/**"
+      - "packages/yjs-binding/**"
   workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write  # Required for pkg-pr-new PR comments
-  id-token: write       # Required for npm provenance / trusted publishing
+  pull-requests: write # Required for pkg-pr-new PR comments
+  id-token: write # Required for npm provenance / trusted publishing
 
 jobs:
   publish:
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: "22.14.0"
           # Only point at npmjs on a tag publish; previews use pkg.pr.new and need no registry.
           registry-url: ${{ startsWith(github.ref, 'refs/tags/v') && 'https://registry.npmjs.org' || '' }}
 

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -22,7 +22,9 @@
       "@excalidraw/utils": ["./utils/src/index.ts"],
       "@excalidraw/utils/*": ["./utils/src/*"],
       "@excalidraw/fractional-indexing": ["./fractional-indexing/src/index.ts"],
-      "@excalidraw/fractional-indexing/*": ["./fractional-indexing/src/*"]
+      "@excalidraw/fractional-indexing/*": ["./fractional-indexing/src/*"],
+      "@alkemio/excalidraw-yjs-binding": ["./yjs-binding/src/index.ts"],
+      "@alkemio/excalidraw-yjs-binding/*": ["./yjs-binding/src/*"]
     }
   }
 }

--- a/packages/yjs-binding/.eslintrc.json
+++ b/packages/yjs-binding/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../eslintrc.base.json"]
+}

--- a/packages/yjs-binding/global.d.ts
+++ b/packages/yjs-binding/global.d.ts
@@ -1,0 +1,3 @@
+// Placeholder for package-local ambient declarations, mirroring the other
+// monorepo packages (e.g. fractional-indexing/global.d.ts).
+export {};

--- a/packages/yjs-binding/global.d.ts
+++ b/packages/yjs-binding/global.d.ts
@@ -1,3 +1,9 @@
-// Placeholder for package-local ambient declarations, mirroring the other
-// monorepo packages (e.g. fractional-indexing/global.d.ts).
-export {};
+// Package-local ambient declarations. The binding imports
+// `@excalidraw/excalidraw/types`, so `tsc` (via the monorepo `paths` →
+// source) follows into the Excalidraw editor source tree during `gen:types`.
+// That source relies on these ambient augmentations, so we pull them in here —
+// mirroring `@excalidraw/utils/global.d.ts`, the other leaf package that
+// compiles against Excalidraw source.
+/// <reference types="vite/client" />
+import "@excalidraw/excalidraw/global";
+import "@excalidraw/excalidraw/css";

--- a/packages/yjs-binding/package.json
+++ b/packages/yjs-binding/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@alkemio/excalidraw-yjs-binding",
+  "version": "0.18.0",
+  "type": "module",
+  "types": "./dist/types/yjs-binding/src/index.d.ts",
+  "main": "./dist/prod/index.js",
+  "module": "./dist/prod/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/types/yjs-binding/src/index.d.ts",
+      "development": "./dist/dev/index.js",
+      "production": "./dist/prod/index.js",
+      "default": "./dist/prod/index.js"
+    },
+    "./*": {
+      "types": "./dist/types/yjs-binding/src/*.d.ts",
+      "development": "./dist/dev/index.js",
+      "production": "./dist/prod/index.js",
+      "default": "./dist/prod/index.js"
+    }
+  },
+  "files": [
+    "dist/*"
+  ],
+  "description": "Per-property Yjs CRDT binding for the Excalidraw whiteboard scene (transport-agnostic).",
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "keywords": [
+    "excalidraw",
+    "yjs",
+    "crdt",
+    "collaboration",
+    "whiteboard"
+  ],
+  "bugs": "https://github.com/alkem-io/excalidraw-fork/issues",
+  "repository": "https://github.com/alkem-io/excalidraw-fork",
+  "scripts": {
+    "gen:types": "rimraf types && tsc",
+    "build:esm": "rimraf dist && node ../../scripts/buildBase.js && yarn gen:types"
+  },
+  "dependencies": {
+    "@excalidraw/element": "0.18.0",
+    "@excalidraw/fractional-indexing": "3.3.0",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.27"
+  }
+}

--- a/packages/yjs-binding/package.json
+++ b/packages/yjs-binding/package.json
@@ -38,7 +38,9 @@
   "repository": "https://github.com/alkem-io/excalidraw-fork",
   "scripts": {
     "gen:types": "rimraf types && tsc",
-    "build:esm": "rimraf dist && node ../../scripts/buildBase.js && yarn gen:types"
+    "build:esm": "rimraf dist && node ../../scripts/buildBase.js && yarn gen:types",
+    "build": "yarn build:esm",
+    "test": "vitest run --root ../.. packages/yjs-binding"
   },
   "dependencies": {
     "@excalidraw/element": "0.18.0",

--- a/packages/yjs-binding/package.json
+++ b/packages/yjs-binding/package.json
@@ -45,5 +45,8 @@
     "@excalidraw/fractional-indexing": "3.3.0",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.27"
+  },
+  "peerDependencies": {
+    "@alkemio/excalidraw": ">=0.18.0"
   }
 }

--- a/packages/yjs-binding/src/apply.ts
+++ b/packages/yjs-binding/src/apply.ts
@@ -1,0 +1,208 @@
+import { CaptureUpdateAction } from "@excalidraw/element";
+
+import type {
+  AppState,
+  BinaryFileData,
+  ExcalidrawImperativeAPI,
+} from "@excalidraw/excalidraw/types";
+
+import { BINDING_ORIGIN, APPSTATE_ALLOW_LIST, yMapToElement } from "./schema";
+import { orderByIndex, repairIndices } from "./order";
+import { readFiles } from "./files";
+
+import type * as Y from "yjs";
+import type { ElementRecord } from "./schema";
+
+/**
+ * The Yjs observe → scene apply path (data-model §8 Apply). Reads the changed
+ * portion of the doc, rebuilds only the affected elements, repairs ordering,
+ * filters tombstones for render, and calls `updateScene` without disturbing
+ * local selection/zoom/scroll.
+ */
+
+export type ApplyRoots = {
+  ydoc: Y.Doc;
+  elementsMap: Y.Map<Y.Map<unknown>>;
+  filesMap: Y.Map<BinaryFileData>;
+  appStateMap: Y.Map<unknown>;
+};
+
+/** Hook telling apply which element id (if any) the local user is mid-editing. */
+export type EditingGuard = () => string | null;
+
+/** A simple random-ish nonce for the local version bump (OPEN-3). */
+const randomNonce = (): number => Math.floor(Math.random() * 2 ** 31);
+
+/**
+ * Build the full element list from the doc's element maps, ordered by `index`
+ * with collision repair (T012–T014). Tombstones are retained in the returned
+ * list (the caller filters them for render); `repaired` carries the ids whose
+ * `index` was changed so the caller can persist the repair under
+ * `BINDING_ORIGIN`.
+ *
+ * `prevById` supplies the previous local element objects so that
+ * `version`/`versionNonce` can be bumped locally on a real per-property change
+ * (OPEN-3) rather than carried verbatim from the remote.
+ */
+export const buildElements = (
+  elementsMap: Y.Map<Y.Map<unknown>>,
+  prevById: Map<string, ElementRecord>,
+): { elements: ElementRecord[]; repaired: Set<string> } => {
+  const elements: ElementRecord[] = [];
+  for (const [id, ymap] of elementsMap.entries()) {
+    const next = yMapToElement(ymap);
+    next.id = id;
+    bumpVersion(next, prevById.get(id));
+    elements.push(next);
+  }
+  const { ordered, repaired } = repairIndices(elements);
+  return { elements: ordered, repaired };
+};
+
+/**
+ * Recompute `version`/`versionNonce` locally when the materialized element
+ * differs from the previous local one (OPEN-3) — keeps Excalidraw's version
+ * monotonic and `hashElementsVersion()` change-detection meaningful. When the
+ * element is unchanged, the previous version/nonce are preserved (no churn).
+ */
+const bumpVersion = (
+  next: ElementRecord,
+  prev: ElementRecord | undefined,
+): void => {
+  if (!prev) {
+    // first time we see this element locally — keep whatever version it carries
+    if (typeof next.version !== "number") {
+      next.version = 1;
+    }
+    if (typeof next.versionNonce !== "number") {
+      next.versionNonce = randomNonce();
+    }
+    return;
+  }
+  // compare every key except the version metadata itself
+  let changed = false;
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  for (const key of keys) {
+    if (key === "version" || key === "versionNonce" || key === "updated") {
+      continue;
+    }
+    if (JSON.stringify(prev[key]) !== JSON.stringify(next[key])) {
+      changed = true;
+      break;
+    }
+  }
+  if (changed) {
+    next.version = ((prev.version as number) ?? 0) + 1;
+    next.versionNonce = randomNonce();
+    next.updated = Date.now();
+  } else {
+    next.version = prev.version;
+    next.versionNonce = prev.versionNonce;
+    next.updated = prev.updated;
+  }
+};
+
+/** Read the synced `APPSTATE` allow-list from the doc (OPEN-2). */
+export const readAppState = (
+  appStateMap: Y.Map<unknown>,
+): Partial<Pick<AppState, "viewBackgroundColor"> & { name: string }> => {
+  const result: Record<string, unknown> = {};
+  for (const key of APPSTATE_ALLOW_LIST) {
+    if (appStateMap.has(key)) {
+      result[key] = appStateMap.get(key);
+    }
+  }
+  return result;
+};
+
+export type ApplyDeps = {
+  roots: ApplyRoots;
+  api: Pick<
+    ExcalidrawImperativeAPI,
+    "updateScene" | "addFiles" | "getFiles" | "getSceneElementsIncludingDeleted"
+  >;
+  /** returns the previous full element list applied (for version-bump compare) */
+  getPrevElements: () => readonly ElementRecord[];
+  /** id of the element the local user is mid-editing, or null */
+  editingGuard?: EditingGuard;
+};
+
+/**
+ * Apply the current doc state to the scene (T011–T016). Caller has already
+ * confirmed the triggering transaction is NOT ours (echo guard lives in the
+ * observer wiring in index.ts, but we re-assert it where a transaction is
+ * available). Returns the element list applied.
+ */
+export const applyToScene = (deps: ApplyDeps): ElementRecord[] => {
+  const { roots, api, getPrevElements, editingGuard } = deps;
+  const { ydoc, elementsMap, filesMap, appStateMap } = roots;
+
+  const prevElements = getPrevElements();
+  const prevById = new Map<string, ElementRecord>(
+    prevElements.map((el) => [el.id as string, el]),
+  );
+
+  const { elements, repaired } = buildElements(elementsMap, prevById);
+
+  // Persist index-collision repairs back into the doc under our origin so they
+  // are treated as a local change (not echoed) and converge across replicas.
+  if (repaired.size > 0) {
+    ydoc.transact(() => {
+      for (const el of elements) {
+        if (repaired.has(el.id as string)) {
+          const ymap = elementsMap.get(el.id as string);
+          if (ymap && ymap.get("index") !== el.index) {
+            ymap.set("index", el.index);
+          }
+        }
+      }
+    }, BINDING_ORIGIN);
+  }
+
+  // Editing guard (FR-B-013): keep the LIVE local copy of an element the user is
+  // mid-editing (read from the editor's scene, which holds the in-progress edit)
+  // instead of replacing it from the remote.
+  const editingId = editingGuard ? editingGuard() : null;
+  let applied = elements;
+  if (editingId) {
+    const liveLocal = api
+      .getSceneElementsIncludingDeleted()
+      .find((el) => (el as ElementRecord).id === editingId) as
+      | ElementRecord
+      | undefined;
+    const localEditing = liveLocal ?? prevById.get(editingId);
+    if (localEditing) {
+      applied = elements.map((el) => (el.id === editingId ? localEditing : el));
+    }
+  }
+
+  // Files: add any new binaries the editor doesn't have yet.
+  const docFiles = readFiles(filesMap);
+  const existingFiles = api.getFiles();
+  const newFiles: BinaryFileData[] = [];
+  for (const id of Object.keys(docFiles)) {
+    if (!existingFiles[id]) {
+      newFiles.push(docFiles[id]);
+    }
+  }
+  if (newFiles.length > 0) {
+    api.addFiles(newFiles);
+  }
+
+  // Render set excludes tombstones; the full set (incl. tombstones) is what we
+  // hand to updateScene so the soft-delete state is preserved in the scene.
+  const renderElements = orderByIndex(applied);
+
+  api.updateScene({
+    elements: renderElements as never,
+    appState: readAppState(appStateMap) as never,
+    captureUpdate: CaptureUpdateAction.NEVER,
+  });
+
+  return applied;
+};
+
+/** Filter tombstones for callers that need the rendered (non-deleted) set. */
+export const nonDeleted = (
+  elements: readonly ElementRecord[],
+): ElementRecord[] => elements.filter((el) => el.isDeleted !== true);

--- a/packages/yjs-binding/src/apply.ts
+++ b/packages/yjs-binding/src/apply.ts
@@ -9,8 +9,10 @@ import type {
 import {
   BINDING_ORIGIN,
   APPSTATE_ALLOW_LIST,
+  BOUND_ELEMENTS_KEY,
   yMapToElement,
   deepEqual,
+  extraBoundTextIds,
 } from "./schema";
 import { orderByIndex, repairIndices } from "./order";
 import { readFiles } from "./files";
@@ -35,8 +37,27 @@ export type ApplyRoots = {
 /** Hook telling apply which element id (if any) the local user is mid-editing. */
 export type EditingGuard = () => string | null;
 
-/** A simple random-ish nonce for the local version bump (OPEN-3). */
-const randomNonce = (): number => Math.floor(Math.random() * 2 ** 31);
+/**
+ * Deterministic `versionNonce` derived from `(id, version)` — a stable 31-bit
+ * FNV-1a hash. Replaces the old `Math.random()` nonce (OPEN-3): because
+ * `version`/`versionNonce`/`updated` are NOT synced (RECONCILE_META_KEYS),
+ * minting a random nonce on every remote apply made apply non-idempotent and
+ * (before the metadata was excluded) round-tripped into the doc, driving the
+ * cross-replica echo loop. A deterministic nonce makes a re-apply of identical
+ * doc state idempotent, while a real change (which bumps `version`) still yields
+ * a different nonce so Excalidraw's reconciliation/change-detection stays
+ * meaningful.
+ */
+const deriveNonce = (id: string, version: number): number => {
+  let hash = 0x811c9dc5;
+  const input = `${id}:${version}`;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  // fold to a non-negative 31-bit integer (matches Excalidraw's nonce range)
+  return (hash >>> 0) % 2 ** 31;
+};
 
 /**
  * Build the full element list from the doc's element maps, ordered by `index`
@@ -74,17 +95,21 @@ const bumpVersion = (
   next: ElementRecord,
   prev: ElementRecord | undefined,
 ): void => {
+  const id = next.id as string;
   if (!prev) {
-    // first time we see this element locally — keep whatever version it carries
-    if (typeof next.version !== "number") {
-      next.version = 1;
-    }
-    if (typeof next.versionNonce !== "number") {
-      next.versionNonce = randomNonce();
+    // First time we see this element locally. The doc never carries
+    // version/versionNonce/updated (RECONCILE_META_KEYS), so seed them
+    // deterministically from doc-derived state.
+    const version =
+      typeof next.version === "number" && next.version > 0 ? next.version : 1;
+    next.version = version;
+    next.versionNonce = deriveNonce(id, version);
+    if (typeof next.updated !== "number") {
+      next.updated = version;
     }
     return;
   }
-  // compare every key except the version metadata itself
+  // compare every key except the reconciliation metadata itself
   let changed = false;
   const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
   for (const key of keys) {
@@ -97,9 +122,12 @@ const bumpVersion = (
     }
   }
   if (changed) {
-    next.version = ((prev.version as number) ?? 0) + 1;
-    next.versionNonce = randomNonce();
-    next.updated = Date.now();
+    const version = ((prev.version as number) ?? 0) + 1;
+    next.version = version;
+    // Deterministic, NOT Math.random() — keeps a re-apply of identical doc state
+    // idempotent (no spurious onChange diff → no echo).
+    next.versionNonce = deriveNonce(id, version);
+    next.updated = version;
   } else {
     next.version = prev.version;
     next.versionNonce = prev.versionNonce;
@@ -164,6 +192,15 @@ export const applyToScene = (deps: ApplyDeps): ElementRecord[] => {
     }, BINDING_ORIGIN);
   }
 
+  // Reconcile the "at most one bound text" invariant INTO the doc (Fix #6).
+  // `yMapToBoundElements` already drops extra text bindings on read, but if the
+  // doc keeps them, the very next onChange diffs the (one-text) scene against the
+  // (two-text) doc and deletes the extra text — flapping with the peer that
+  // holds it. Deleting the extra ids here (deterministically: keep lowest id)
+  // makes doc and scene agree, and because every replica resolves identically it
+  // converges instead of flapping. Written under BINDING_ORIGIN (not echoed).
+  reconcileBoundTextInvariant(ydoc, elementsMap);
+
   // Editing guard (FR-B-013): keep the LIVE local copy of an element the user is
   // mid-editing (read from the editor's scene, which holds the in-progress edit)
   // instead of replacing it from the remote.
@@ -181,12 +218,19 @@ export const applyToScene = (deps: ApplyDeps): ElementRecord[] => {
     }
   }
 
-  // Files: add any new binaries the editor doesn't have yet.
+  // Files: add any binary the editor lacks OR whose bytes changed in the doc
+  // (e.g. a remote image replacement reuses the same fileId with a new dataURL).
+  // The old `!existingFiles[id]` filter only ADDED new ids, silently dropping
+  // updates to an existing id (Fix #2).
   const docFiles = readFiles(filesMap);
-  const existingFiles = api.getFiles();
+  const existingFiles = api.getFiles() as Record<
+    string,
+    BinaryFileData | undefined
+  >;
   const newFiles: BinaryFileData[] = [];
   for (const id of Object.keys(docFiles)) {
-    if (!existingFiles[id]) {
+    const existing = existingFiles[id];
+    if (!existing || !deepEqual(existing, docFiles[id])) {
       newFiles.push(docFiles[id]);
     }
   }
@@ -207,6 +251,48 @@ export const applyToScene = (deps: ApplyDeps): ElementRecord[] => {
 
   return applied;
 };
+
+/**
+ * Delete extra `type:"text"` bound-element entries (every text except the lowest
+ * id) from every element's nested `boundElements` `Y.Map`, so the doc satisfies
+ * the "at most one bound text" invariant that `yMapToBoundElements` enforces on
+ * read (Fix #6). Idempotent and deterministic across replicas → converges. Only
+ * opens a transaction if there is something to delete (no empty BINDING_ORIGIN
+ * transaction on the common case).
+ */
+const reconcileBoundTextInvariant = (
+  ydoc: Y.Doc,
+  elementsMap: Y.Map<Y.Map<unknown>>,
+): void => {
+  const toDrop: Array<{ nested: Y.Map<unknown>; ids: string[] }> = [];
+  for (const [, ymap] of elementsMap.entries()) {
+    const nested = ymap.get(BOUND_ELEMENTS_KEY);
+    if (!isYMap(nested)) {
+      continue;
+    }
+    const extra = extraBoundTextIds(nested as Y.Map<"arrow" | "text">);
+    if (extra.length > 0) {
+      toDrop.push({ nested, ids: extra });
+    }
+  }
+  if (toDrop.length === 0) {
+    return;
+  }
+  ydoc.transact(() => {
+    for (const { nested, ids } of toDrop) {
+      for (const id of ids) {
+        nested.delete(id);
+      }
+    }
+  }, BINDING_ORIGIN);
+};
+
+/** Narrow an unknown nested value to a `Y.Map` without importing the class. */
+const isYMap = (value: unknown): value is Y.Map<unknown> =>
+  value != null &&
+  typeof value === "object" &&
+  typeof (value as { delete?: unknown }).delete === "function" &&
+  typeof (value as { entries?: unknown }).entries === "function";
 
 /** Filter tombstones for callers that need the rendered (non-deleted) set. */
 export const nonDeleted = (

--- a/packages/yjs-binding/src/apply.ts
+++ b/packages/yjs-binding/src/apply.ts
@@ -194,8 +194,9 @@ export const applyToScene = (deps: ApplyDeps): ElementRecord[] => {
     api.addFiles(newFiles);
   }
 
-  // Render set excludes tombstones; the full set (incl. tombstones) is what we
-  // hand to updateScene so the soft-delete state is preserved in the scene.
+  // Hand the full set (incl. tombstones) to updateScene so the soft-delete
+  // state is preserved in the scene; the host filters non-deleted elements for
+  // render. `orderByIndex` only sorts — it does not drop tombstones.
   const renderElements = orderByIndex(applied);
 
   api.updateScene({

--- a/packages/yjs-binding/src/apply.ts
+++ b/packages/yjs-binding/src/apply.ts
@@ -6,7 +6,12 @@ import type {
   ExcalidrawImperativeAPI,
 } from "@excalidraw/excalidraw/types";
 
-import { BINDING_ORIGIN, APPSTATE_ALLOW_LIST, yMapToElement } from "./schema";
+import {
+  BINDING_ORIGIN,
+  APPSTATE_ALLOW_LIST,
+  yMapToElement,
+  deepEqual,
+} from "./schema";
 import { orderByIndex, repairIndices } from "./order";
 import { readFiles } from "./files";
 
@@ -86,7 +91,7 @@ const bumpVersion = (
     if (key === "version" || key === "versionNonce" || key === "updated") {
       continue;
     }
-    if (JSON.stringify(prev[key]) !== JSON.stringify(next[key])) {
+    if (!deepEqual(prev[key], next[key])) {
       changed = true;
       break;
     }

--- a/packages/yjs-binding/src/awareness.ts
+++ b/packages/yjs-binding/src/awareness.ts
@@ -79,8 +79,20 @@ export class AwarenessRouter {
     this.api = deps.api;
     this.ephemeral = deps.ephemeral;
 
-    // Remote awareness → collaborator cursors (touches no elements).
-    const onChange = () => this.applyRemoteAwareness();
+    // Remote awareness → collaborator cursors (touches no elements). The
+    // y-protocols 'change' event passes an origin; LOCAL-origin changes (our own
+    // cursor/selection moves via setLocalStateField) must NOT trigger an
+    // applyRemoteAwareness → updateScene → onChange cycle — only remote peers'
+    // state does (Fix #7).
+    const onChange = (
+      _changes: { added: number[]; updated: number[]; removed: number[] },
+      origin: unknown,
+    ) => {
+      if (origin === "local") {
+        return;
+      }
+      this.applyRemoteAwareness();
+    };
     this.awareness.on("change", onChange);
     this.cleanups.push(() => this.awareness.off("change", onChange));
 
@@ -175,5 +187,14 @@ export class AwarenessRouter {
       cleanup();
     }
     this.cleanups.length = 0;
+    // Clear our local presence on teardown so peers drop this client's cursor
+    // immediately instead of waiting ~30s for the awareness timeout to expire
+    // (Fix #7 — no ghost cursor after unmount). This emits a 'removed' change to
+    // other clients; our own handler is already detached above.
+    try {
+      this.awareness.setLocalState(null);
+    } catch {
+      // awareness may already be destroyed (e.g. its doc was destroyed first)
+    }
   }
 }

--- a/packages/yjs-binding/src/awareness.ts
+++ b/packages/yjs-binding/src/awareness.ts
@@ -1,0 +1,179 @@
+import type {
+  Collaborator,
+  ExcalidrawImperativeAPI,
+  SocketId,
+} from "@excalidraw/excalidraw/types";
+
+import type { Awareness } from "y-protocols/awareness";
+
+/**
+ * Ephemeral state routing (data-model §7, FR-B-008). Cursors, selection,
+ * idle/mode go to y-protocols **awareness**; emoji reactions, the countdown
+ * timer, and visible-scene-bounds go to the **ephemeral** event channel. NONE
+ * of this is ever written to the scene `Y.Doc` — putting presence in the doc
+ * would persist transient state and corrupt the merge/diff model.
+ *
+ * The ephemeral event channel is transport-agnostic here: it is modelled as a
+ * pluggable `send`/`receive` pair so WS-D can wire it to the `2` Ephemeral WS
+ * message type without this package knowing about sockets.
+ */
+
+export type PointerPayload = {
+  pointer: { x: number; y: number; tool?: "pointer" | "laser" } | null;
+  button: "up" | "down";
+  pointersMap?: Map<number, { x: number; y: number }>;
+};
+
+export type EmojiReactionPayload = {
+  id: string;
+  emoji: string;
+  x: number;
+  y: number;
+};
+
+export type CountdownTimerPayload = {
+  remainingSeconds: number;
+  startedBy: string;
+  active: boolean;
+};
+
+export type VisibleSceneBoundsPayload = {
+  sceneBounds: [number, number, number, number];
+};
+
+/** Ephemeral event kinds carried out-of-band (never in the scene doc). */
+export type EphemeralEvent =
+  | { type: "EMOJI_REACTION"; payload: EmojiReactionPayload }
+  | { type: "COUNTDOWN_TIMER"; payload: CountdownTimerPayload }
+  | { type: "USER_VISIBLE_SCENE_BOUNDS"; payload: VisibleSceneBoundsPayload };
+
+/** Transport seam for the ephemeral channel (WS-D plugs the real one in). */
+export type EphemeralChannel = {
+  send: (event: EphemeralEvent) => void;
+  subscribe: (handler: (event: EphemeralEvent) => void) => () => void;
+};
+
+export type AwarenessRouterDeps = {
+  awareness: Awareness;
+  api: Pick<
+    ExcalidrawImperativeAPI,
+    | "updateScene"
+    | "dispatchIncomingEmojiReaction"
+    | "dispatchIncomingCountdownTimer"
+  >;
+  ephemeral?: EphemeralChannel;
+};
+
+/**
+ * Routes ephemeral state to/from awareness + the ephemeral channel, keeping the
+ * scene `Y.Doc` byte-untouched (US4 / SC-B-004).
+ */
+export class AwarenessRouter {
+  private readonly awareness: Awareness;
+  private readonly api: AwarenessRouterDeps["api"];
+  private readonly ephemeral?: EphemeralChannel;
+  private readonly cleanups: Array<() => void> = [];
+
+  constructor(deps: AwarenessRouterDeps) {
+    this.awareness = deps.awareness;
+    this.api = deps.api;
+    this.ephemeral = deps.ephemeral;
+
+    // Remote awareness → collaborator cursors (touches no elements).
+    const onChange = () => this.applyRemoteAwareness();
+    this.awareness.on("change", onChange);
+    this.cleanups.push(() => this.awareness.off("change", onChange));
+
+    // Incoming ephemeral events → imperative dispatch.
+    if (this.ephemeral) {
+      const unsub = this.ephemeral.subscribe((event) =>
+        this.dispatchIncoming(event),
+      );
+      this.cleanups.push(unsub);
+    }
+  }
+
+  /** Local pointer move → awareness (FR-B-008). Never the scene doc. */
+  onPointerUpdate(payload: PointerPayload): void {
+    this.awareness.setLocalStateField("pointer", payload.pointer);
+    this.awareness.setLocalStateField("button", payload.button);
+  }
+
+  /** Local selection highlight → awareness. */
+  onSelectionChange(selectedElementIds: Record<string, true>): void {
+    this.awareness.setLocalStateField("selectedElementIds", selectedElementIds);
+  }
+
+  /** Local idle status → awareness. */
+  onIdleChange(userState: string): void {
+    this.awareness.setLocalStateField("userState", userState);
+  }
+
+  /** Local user identity → awareness. */
+  setUser(user: Record<string, unknown>): void {
+    this.awareness.setLocalStateField("user", user);
+  }
+
+  /** Local emoji reaction → ephemeral channel (never the scene doc). */
+  broadcastEmojiReaction(payload: EmojiReactionPayload): void {
+    this.ephemeral?.send({ type: "EMOJI_REACTION", payload });
+  }
+
+  /** Local countdown timer → ephemeral channel. */
+  broadcastCountdownTimer(payload: CountdownTimerPayload): void {
+    this.ephemeral?.send({ type: "COUNTDOWN_TIMER", payload });
+  }
+
+  /** Local visible-scene-bounds (follow mode) → ephemeral channel. */
+  broadcastVisibleSceneBounds(payload: VisibleSceneBoundsPayload): void {
+    this.ephemeral?.send({ type: "USER_VISIBLE_SCENE_BOUNDS", payload });
+  }
+
+  /** Dispatch an incoming ephemeral event to the editor. */
+  private dispatchIncoming(event: EphemeralEvent): void {
+    switch (event.type) {
+      case "EMOJI_REACTION":
+        this.api.dispatchIncomingEmojiReaction(event.payload);
+        break;
+      case "COUNTDOWN_TIMER":
+        this.api.dispatchIncomingCountdownTimer(event.payload);
+        break;
+      case "USER_VISIBLE_SCENE_BOUNDS":
+        // follow-mode bounds are consumed by the host (WS-D); no-op here.
+        break;
+      default:
+        break;
+    }
+  }
+
+  /** Map remote awareness states → collaborators and apply via updateScene. */
+  private applyRemoteAwareness(): void {
+    const collaborators = new Map<SocketId, Collaborator>();
+    const states = this.awareness.getStates();
+    for (const [clientId, state] of states) {
+      if (clientId === this.awareness.clientID) {
+        continue; // skip self
+      }
+      const socketId = String(clientId) as SocketId;
+      collaborators.set(socketId, {
+        pointer: state.pointer ?? undefined,
+        button: state.button ?? undefined,
+        selectedElementIds: state.selectedElementIds ?? undefined,
+        userState: state.userState ?? undefined,
+        username: state.user?.username ?? undefined,
+        avatarUrl: state.user?.avatarUrl ?? undefined,
+        color: state.user?.color ?? undefined,
+        id: state.user?.id ?? undefined,
+        socketId,
+      });
+    }
+    this.api.updateScene({ collaborators });
+  }
+
+  destroy(): void {
+    for (const cleanup of this.cleanups) {
+      cleanup();
+    }
+    this.cleanups.length = 0;
+  }
+}

--- a/packages/yjs-binding/src/diff.ts
+++ b/packages/yjs-binding/src/diff.ts
@@ -8,13 +8,14 @@ import type {
   BinaryFiles,
 } from "@excalidraw/excalidraw/types";
 
-import { diffFiles } from "./files";
+import { diffFiles, referencedFileIds } from "./files";
 import { keyBetween } from "./order";
 import {
   APPSTATE_ALLOW_LIST,
   BINDING_ORIGIN,
   BOUND_ELEMENTS_KEY,
   JSON_LEAF_KEYS,
+  RECONCILE_META_KEYS,
   deepEqual,
   elementToYMap,
   writeChangedKeys,
@@ -103,7 +104,7 @@ export const writeDiff = (
       // neighbour bounds from already-resolved indices around it in array order
       const prevIndex = findPrevIndex(next, i, generatedIndex);
       const nextIndex = findNextIndex(next, i, generatedIndex);
-      generatedIndex.set(el.id as string, keyBetween(prevIndex, nextIndex));
+      generatedIndex.set(el.id as string, safeKeyBetween(prevIndex, nextIndex));
     }
   }
 
@@ -125,31 +126,40 @@ export const writeDiff = (
       } else {
         const seeded: ElementRecord = { ...element };
         if (seeded.index == null) {
-          seeded.index = generatedIndex.get(id) ?? keyBetween(null, null);
+          seeded.index = generatedIndex.get(id) ?? safeKeyBetween(null, null);
         }
         elementsMap.set(id, elementToYMap(seeded));
         writes++;
       }
     }
 
-    // removals → tombstone (never Y.Map.delete)
-    for (const [id, prevEl] of prevById) {
+    // removals → tombstone (never Y.Map.delete). Only `isDeleted` is synced;
+    // `version`/`versionNonce`/`updated` are per-peer reconciliation metadata
+    // (RECONCILE_META_KEYS) and are derived locally on apply, so the old
+    // non-monotonic `version` write (which read the LOCAL prev.version and could
+    // dip below a concurrent remote bump) is gone — Fix #5 is subsumed by Fix #1.
+    for (const [id] of prevById) {
       if (!nextById.has(id)) {
         const ymap = elementsMap.get(id);
         if (ymap && ymap.get("isDeleted") !== true) {
           ymap.set("isDeleted", true);
-          ymap.set(
-            "version",
-            (((prevEl.version as number) ?? 0) + 1) as number,
-          );
           writes++;
         }
       }
     }
 
-    // files
+    // files — protect any binary still referenced by an element (live OR
+    // tombstoned) in the doc, or referenced by the incoming scene, from deletion
+    // when `files` is transiently partial during async image loading (Fix #3).
     if (files) {
-      writes += diffFiles(filesMap, files);
+      const protectedIds = referencedFileIds(elementsMap);
+      for (const el of next) {
+        const fileId = el.fileId;
+        if (typeof fileId === "string") {
+          protectedIds.add(fileId);
+        }
+      }
+      writes += diffFiles(filesMap, files, protectedIds);
     }
 
     // appState allow-list (OPEN-2): viewBackgroundColor + name
@@ -159,6 +169,31 @@ export const writeDiff = (
   }, BINDING_ORIGIN);
 
   return writes;
+};
+
+/**
+ * `keyBetween` that never throws on non-strictly-increasing bounds (Fix #8).
+ *
+ * `generateKeyBetween(prev, next)` throws when `prev >= next`. The neighbour
+ * bounds here come from the INPUT array order, which Excalidraw does NOT
+ * guarantee to be index-sorted — a reorder or mid-edit onChange can present
+ * descending indices around an indexless insert. A throw would abort the ENTIRE
+ * onChange write (every mutation in the transaction lost). When the bounds are
+ * invalid we drop the upper bound (seed just above `prev`, or anywhere if both
+ * are null); the result may not be strictly increasing, but `repairIndices`
+ * deterministically fixes ordering on the next apply — far better than losing
+ * the write.
+ */
+const safeKeyBetween = (prev: string | null, next: string | null): string => {
+  try {
+    return keyBetween(prev, next);
+  } catch {
+    try {
+      return keyBetween(prev, null);
+    } catch {
+      return keyBetween(null, null);
+    }
+  }
 };
 
 const findPrevIndex = (
@@ -254,8 +289,17 @@ const hasDiffWork = (
   // files
   if (files) {
     const nextIds = new Set(Object.keys(files));
+    // mirror diffFiles' protection (Fix #3): a doc file absent from `files` is
+    // only a real removal if no element (live or tombstoned) still references it.
+    const protectedIds = referencedFileIds(elementsMap);
+    for (const el of next) {
+      const fileId = el.fileId;
+      if (typeof fileId === "string") {
+        protectedIds.add(fileId);
+      }
+    }
     for (const id of filesMap.keys()) {
-      if (!nextIds.has(id)) {
+      if (!nextIds.has(id) && !protectedIds.has(id)) {
         return true;
       }
     }
@@ -285,8 +329,20 @@ const elementChanged = (
   element: ElementRecord,
 ): boolean => {
   for (const key of Object.keys(element)) {
+    if (RECONCILE_META_KEYS.has(key)) {
+      // version/versionNonce/updated are not synced — never a change signal.
+      continue;
+    }
     const next = element[key];
     if (next === undefined) {
+      // value → absent: a write is needed iff the doc still holds it.
+      if (key === BOUND_ELEMENTS_KEY) {
+        if (boundElementsChanged(ymap, null)) {
+          return true;
+        }
+      } else if (ymap.has(key)) {
+        return true;
+      }
       continue;
     }
     if (key === BOUND_ELEMENTS_KEY) {
@@ -301,6 +357,18 @@ const elementChanged = (
         return true;
       }
     } else if (prev !== next) {
+      return true;
+    }
+  }
+  // a doc key dropped entirely from the element (and not meta/id/boundElements)
+  // needs clearing → a change.
+  for (const key of ymap.keys()) {
+    if (
+      key !== "id" &&
+      key !== BOUND_ELEMENTS_KEY &&
+      !RECONCILE_META_KEYS.has(key) &&
+      !Object.prototype.hasOwnProperty.call(element, key)
+    ) {
       return true;
     }
   }

--- a/packages/yjs-binding/src/diff.ts
+++ b/packages/yjs-binding/src/diff.ts
@@ -1,0 +1,334 @@
+import * as Y from "yjs";
+
+import type { BoundElement } from "@excalidraw/element/types";
+
+import type {
+  AppState,
+  BinaryFileData,
+  BinaryFiles,
+} from "@excalidraw/excalidraw/types";
+
+import { diffFiles } from "./files";
+import { keyBetween } from "./order";
+import {
+  APPSTATE_ALLOW_LIST,
+  BINDING_ORIGIN,
+  BOUND_ELEMENTS_KEY,
+  JSON_LEAF_KEYS,
+  deepEqual,
+  elementToYMap,
+  writeChangedKeys,
+} from "./schema";
+
+import type { BoundElementType, ElementRecord } from "./schema";
+
+/**
+ * The onChange → Yjs write path (data-model §8 Diff). Translates an Excalidraw
+ * `onChange(elements, appState, files)` into the minimal set of per-property Yjs
+ * mutations, batched in a single `BINDING_ORIGIN`-tagged transaction.
+ */
+
+/**
+ * Cheap change gate (T006): compare `(id, version)` pairs of the previous and
+ * next element arrays. Returns `true` when nothing changed (skip the write).
+ * Mirrors y-excalidraw's `areElementsSame` fast path.
+ */
+export const areElementsSame = (
+  prev: readonly ElementRecord[],
+  next: readonly ElementRecord[],
+): boolean => {
+  if (prev.length !== next.length) {
+    return false;
+  }
+  for (let i = 0; i < prev.length; i++) {
+    if (prev[i].id !== next[i].id || prev[i].version !== next[i].version) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/** Index a readonly element array by id for O(1) lookup. */
+const byId = (
+  elements: readonly ElementRecord[],
+): Map<string, ElementRecord> => {
+  const map = new Map<string, ElementRecord>();
+  for (const element of elements) {
+    map.set(element.id as string, element);
+  }
+  return map;
+};
+
+export type DiffRoots = {
+  ydoc: Y.Doc;
+  elementsMap: Y.Map<Y.Map<unknown>>;
+  filesMap: Y.Map<BinaryFileData>;
+  appStateMap: Y.Map<unknown>;
+};
+
+/**
+ * Compute and apply the per-property delta between `prev` and `next` element
+ * arrays, plus the files and appState allow-list deltas, in ONE origin-tagged
+ * transaction (T007/T008, FR-B-002).
+ *
+ * - existing element → only changed keys (`writeChangedKeys`); `boundElements`
+ *   diffs into its nested `Y.Map`.
+ * - new element → a fresh element `Y.Map` with all keys; if it has no `index`,
+ *   one is generated between its ordered neighbours via `keyBetween`.
+ * - element removed from the array → tombstone (`isDeleted = true`); the element
+ *   `Y.Map` is NEVER deleted from the scene map (FR-B-006).
+ *
+ * Returns the number of element keys / file / appState mutations written (0 ⇒ no
+ * transaction was emitted).
+ */
+export const writeDiff = (
+  roots: DiffRoots,
+  prev: readonly ElementRecord[],
+  next: readonly ElementRecord[],
+  appState?: Pick<AppState, "viewBackgroundColor"> & { name?: string },
+  files?: BinaryFiles,
+): number => {
+  const { ydoc, elementsMap, filesMap, appStateMap } = roots;
+  const prevById = byId(prev);
+  const nextById = byId(next);
+
+  // Pre-compute fractional indices for any new element that arrives without one,
+  // using its position in the INPUT array (where the editor placed it — a null
+  // index has no sortable position of its own). Done outside the transaction
+  // (pure string math) so the transaction body stays minimal.
+  const generatedIndex = new Map<string, string>();
+  for (let i = 0; i < next.length; i++) {
+    const el = next[i];
+    if (el.index == null && !elementsMap.has(el.id as string)) {
+      // neighbour bounds from already-resolved indices around it in array order
+      const prevIndex = findPrevIndex(next, i, generatedIndex);
+      const nextIndex = findNextIndex(next, i, generatedIndex);
+      generatedIndex.set(el.id as string, keyBetween(prevIndex, nextIndex));
+    }
+  }
+
+  // Cheap pre-pass: decide whether ANY mutation is needed before opening a
+  // transaction. Yjs fires `afterTransaction` even for empty transactions, so a
+  // no-op `onChange` must NOT call `ydoc.transact` at all (SC-B-003).
+  if (!hasDiffWork(roots, prevById, nextById, next, appState, files)) {
+    return 0;
+  }
+
+  let writes = 0;
+  ydoc.transact(() => {
+    // upserts (existing changed + new)
+    for (const element of next) {
+      const id = element.id as string;
+      const existing = elementsMap.get(id);
+      if (existing) {
+        writes += writeChangedKeys(existing, element);
+      } else {
+        const seeded: ElementRecord = { ...element };
+        if (seeded.index == null) {
+          seeded.index = generatedIndex.get(id) ?? keyBetween(null, null);
+        }
+        elementsMap.set(id, elementToYMap(seeded));
+        writes++;
+      }
+    }
+
+    // removals → tombstone (never Y.Map.delete)
+    for (const [id, prevEl] of prevById) {
+      if (!nextById.has(id)) {
+        const ymap = elementsMap.get(id);
+        if (ymap && ymap.get("isDeleted") !== true) {
+          ymap.set("isDeleted", true);
+          ymap.set(
+            "version",
+            (((prevEl.version as number) ?? 0) + 1) as number,
+          );
+          writes++;
+        }
+      }
+    }
+
+    // files
+    if (files) {
+      writes += diffFiles(filesMap, files);
+    }
+
+    // appState allow-list (OPEN-2): viewBackgroundColor + name
+    if (appState) {
+      writes += writeAppState(appStateMap, appState);
+    }
+  }, BINDING_ORIGIN);
+
+  return writes;
+};
+
+const findPrevIndex = (
+  ordered: readonly ElementRecord[],
+  i: number,
+  generated: Map<string, string>,
+): string | null => {
+  for (let k = i - 1; k >= 0; k--) {
+    const el = ordered[k];
+    const idx = (el.index as string | null) ?? generated.get(el.id as string);
+    if (idx != null) {
+      return idx;
+    }
+  }
+  return null;
+};
+
+const findNextIndex = (
+  ordered: readonly ElementRecord[],
+  i: number,
+  generated: Map<string, string>,
+): string | null => {
+  for (let k = i + 1; k < ordered.length; k++) {
+    const el = ordered[k];
+    const idx = (el.index as string | null) ?? generated.get(el.id as string);
+    if (idx != null) {
+      return idx;
+    }
+  }
+  return null;
+};
+
+/**
+ * Diff the `APPSTATE` allow-list (`viewBackgroundColor`, `name`) against the
+ * `appState` `Y.Map` (OPEN-2). Already inside the diff transaction. Returns the
+ * number of keys written.
+ */
+export const writeAppState = (
+  appStateMap: Y.Map<unknown>,
+  appState: Record<string, unknown>,
+): number => {
+  let writes = 0;
+  for (const key of APPSTATE_ALLOW_LIST) {
+    const next = appState[key];
+    if (next === undefined) {
+      continue;
+    }
+    if (appStateMap.get(key) !== next) {
+      appStateMap.set(key, next);
+      writes++;
+    }
+  }
+  return writes;
+};
+
+/**
+ * Read-only pre-pass: returns `true` iff `writeDiff` would mutate anything.
+ * Used to avoid opening an empty transaction for a no-op `onChange` (a no-op must
+ * emit zero transactions — SC-B-003).
+ */
+const hasDiffWork = (
+  roots: DiffRoots,
+  prevById: Map<string, ElementRecord>,
+  nextById: Map<string, ElementRecord>,
+  next: readonly ElementRecord[],
+  appState?: Record<string, unknown>,
+  files?: BinaryFiles,
+): boolean => {
+  const { elementsMap, filesMap, appStateMap } = roots;
+
+  // new / changed elements
+  for (const element of next) {
+    const id = element.id as string;
+    const existing = elementsMap.get(id);
+    if (!existing) {
+      return true; // new element
+    }
+    if (elementChanged(existing, element)) {
+      return true;
+    }
+  }
+
+  // removals (need a tombstone)
+  for (const id of prevById.keys()) {
+    if (!nextById.has(id)) {
+      const ymap = elementsMap.get(id);
+      if (ymap && ymap.get("isDeleted") !== true) {
+        return true;
+      }
+    }
+  }
+
+  // files
+  if (files) {
+    const nextIds = new Set(Object.keys(files));
+    for (const id of filesMap.keys()) {
+      if (!nextIds.has(id)) {
+        return true;
+      }
+    }
+    for (const id of nextIds) {
+      if (!deepEqual(filesMap.get(id), files[id])) {
+        return true;
+      }
+    }
+  }
+
+  // appState allow-list
+  if (appState) {
+    for (const key of APPSTATE_ALLOW_LIST) {
+      const value = appState[key];
+      if (value !== undefined && appStateMap.get(key) !== value) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+/** Whether any per-property key of `element` differs from its `Y.Map`. */
+const elementChanged = (
+  ymap: Y.Map<unknown>,
+  element: ElementRecord,
+): boolean => {
+  for (const key of Object.keys(element)) {
+    const next = element[key];
+    if (next === undefined) {
+      continue;
+    }
+    if (key === BOUND_ELEMENTS_KEY) {
+      if (boundElementsChanged(ymap, next as readonly BoundElement[] | null)) {
+        return true;
+      }
+      continue;
+    }
+    const prev = ymap.get(key);
+    if (JSON_LEAF_KEYS.has(key)) {
+      if (!deepEqual(prev, next)) {
+        return true;
+      }
+    } else if (prev !== next) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/** Whether the nested boundElements map would change for this element. */
+const boundElementsChanged = (
+  ymap: Y.Map<unknown>,
+  boundElements: readonly BoundElement[] | null,
+): boolean => {
+  const nested = ymap.get(BOUND_ELEMENTS_KEY);
+  const nextMap = new Map<string, BoundElementType>();
+  if (boundElements) {
+    for (const b of boundElements) {
+      nextMap.set(b.id, b.type);
+    }
+  }
+  if (!(nested instanceof Y.Map)) {
+    return nextMap.size > 0;
+  }
+  if (nested.size !== nextMap.size) {
+    return true;
+  }
+  for (const [id, type] of nextMap) {
+    if (nested.get(id) !== type) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/packages/yjs-binding/src/files.ts
+++ b/packages/yjs-binding/src/files.ts
@@ -15,17 +15,29 @@ import type * as Y from "yjs";
  * Diff the scene's `files` against the `files` `Y.Map` and apply the delta:
  * append new file ids, update changed ones, remove dropped ones. MUST run inside
  * a `BINDING_ORIGIN` transaction. Returns the number of mutations applied.
+ *
+ * `protectedIds` (Fix #3) — fileIds still referenced by SOME element in the
+ * scene/doc, INCLUDING soft-deleted (tombstoned) image elements. A protected id
+ * is NEVER deleted even when it is absent from the `files` arg, because:
+ *  - during async image loading `files` is transiently partial (the binary has
+ *    not finished loading), so a benign local `onChange` would otherwise delete
+ *    a binary the doc still needs; and
+ *  - a tombstoned image still references its file, so file lifecycle must follow
+ *    element soft-delete, not the live `files` map.
+ * When omitted (e.g. the populate path), behaviour is unchanged.
  */
 export const diffFiles = (
   filesMap: Y.Map<BinaryFileData>,
   files: BinaryFiles,
+  protectedIds?: ReadonlySet<string>,
 ): number => {
   let mutations = 0;
   const nextIds = new Set(Object.keys(files));
 
-  // removals: ids in the map but no longer referenced
+  // removals: ids in the map, not in the next files arg, AND not still
+  // referenced by any (incl. tombstoned / not-yet-loaded) element.
   for (const id of [...filesMap.keys()]) {
-    if (!nextIds.has(id)) {
+    if (!nextIds.has(id) && !protectedIds?.has(id)) {
       filesMap.delete(id);
       mutations++;
     }
@@ -41,6 +53,24 @@ export const diffFiles = (
     }
   }
   return mutations;
+};
+
+/**
+ * Collect the set of fileIds referenced by any element — live OR tombstoned.
+ * Used to protect binaries from deletion while their referencing element still
+ * exists (Fix #3). Reads the `fileId` scalar each image element carries.
+ */
+export const referencedFileIds = (
+  elementsMap: Y.Map<Y.Map<unknown>>,
+): Set<string> => {
+  const ids = new Set<string>();
+  for (const [, ymap] of elementsMap.entries()) {
+    const fileId = ymap.get("fileId");
+    if (typeof fileId === "string") {
+      ids.add(fileId);
+    }
+  }
+  return ids;
 };
 
 /** Read the `files` `Y.Map` back into a plain `BinaryFiles` record. */

--- a/packages/yjs-binding/src/files.ts
+++ b/packages/yjs-binding/src/files.ts
@@ -1,0 +1,53 @@
+import type { BinaryFileData, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import { deepEqual } from "./schema";
+
+import type * as Y from "yjs";
+
+/**
+ * Binary files live in a separate top-level `files` `Y.Map` (FR-B-007),
+ * keyed by `fileId` → `BinaryFileData` stored as a JSON-leaf value. Files are
+ * large and only ever added/removed (never sub-merged), so they are observed
+ * shallowly and kept out of element maps to keep element diffs small.
+ */
+
+/**
+ * Diff the scene's `files` against the `files` `Y.Map` and apply the delta:
+ * append new file ids, update changed ones, remove dropped ones. MUST run inside
+ * a `BINDING_ORIGIN` transaction. Returns the number of mutations applied.
+ */
+export const diffFiles = (
+  filesMap: Y.Map<BinaryFileData>,
+  files: BinaryFiles,
+): number => {
+  let mutations = 0;
+  const nextIds = new Set(Object.keys(files));
+
+  // removals: ids in the map but no longer referenced
+  for (const id of [...filesMap.keys()]) {
+    if (!nextIds.has(id)) {
+      filesMap.delete(id);
+      mutations++;
+    }
+  }
+
+  // additions / changes
+  for (const id of nextIds) {
+    const next = files[id];
+    const prev = filesMap.get(id);
+    if (!prev || !deepEqual(prev, next)) {
+      filesMap.set(id, next);
+      mutations++;
+    }
+  }
+  return mutations;
+};
+
+/** Read the `files` `Y.Map` back into a plain `BinaryFiles` record. */
+export const readFiles = (filesMap: Y.Map<BinaryFileData>): BinaryFiles => {
+  const files: BinaryFiles = {};
+  for (const [id, data] of filesMap.entries()) {
+    files[id] = data;
+  }
+  return files;
+};

--- a/packages/yjs-binding/src/index.ts
+++ b/packages/yjs-binding/src/index.ts
@@ -65,6 +65,16 @@ export class WhiteboardBinding {
   private readonly api: BindingExcalidrawAPI;
   private readonly editingGuard?: EditingGuard;
   private lastKnownElements: ElementRecord[] = [];
+  /**
+   * Re-entrancy guard (FR-B-004). Real Excalidraw fires `onChange` synchronously
+   * from inside `updateScene` (App.componentDidUpdate → onChangeEmitter). Our
+   * own `applyToScene` → `updateScene` would therefore provoke an `onChange` that
+   * re-enters `onSceneChange` and writes the just-applied state straight back
+   * into the doc. We set this flag around `applyToScene` and short-circuit any
+   * `onChange` raised while it is set — independent of writeDiff being a perfect
+   * no-op.
+   */
+  private applying = false;
   private unsubscribeOnChange?: () => void;
   private readonly observeDeepHandler: (
     events: Y.YEvent<Y.AbstractType<unknown>>[],
@@ -113,12 +123,7 @@ export class WhiteboardBinding {
     }
 
     // Apply the current doc state to the scene, seeding lastKnownElements.
-    this.lastKnownElements = applyToScene({
-      roots: this.roots(),
-      api,
-      getPrevElements: () => this.lastKnownElements,
-      editingGuard: this.editingGuard,
-    });
+    this.lastKnownElements = this.applyGuarded();
 
     // observe → apply (echo-guarded)
     this.observeDeepHandler = (_events, transaction) =>
@@ -150,6 +155,24 @@ export class WhiteboardBinding {
     };
   }
 
+  /**
+   * Run `applyToScene` with the re-entrancy guard set, so any `onChange` the
+   * editor fires synchronously from inside `updateScene` is ignored (no echo).
+   */
+  private applyGuarded(): ElementRecord[] {
+    this.applying = true;
+    try {
+      return applyToScene({
+        roots: this.roots(),
+        api: this.api,
+        getPrevElements: () => this.lastKnownElements,
+        editingGuard: this.editingGuard,
+      });
+    } finally {
+      this.applying = false;
+    }
+  }
+
   /** onChange → per-property Yjs write path (FR-B-002). */
   private onSceneChange(
     elements: ElementRecord[],
@@ -157,6 +180,12 @@ export class WhiteboardBinding {
     files: Parameters<Parameters<BindingExcalidrawAPI["onChange"]>[0]>[2],
   ): void {
     if (this.destroyed) {
+      return;
+    }
+    // Re-entrancy guard: this onChange was provoked by our own applyToScene →
+    // updateScene (real Excalidraw re-fires onChange synchronously). Ignore it —
+    // applying remote state must NOT be echoed back into the doc (FR-B-004).
+    if (this.applying) {
       return;
     }
     // Fast path: if no element changed by (id, version), only appState/files can
@@ -183,12 +212,7 @@ export class WhiteboardBinding {
     if (transaction.origin === BINDING_ORIGIN) {
       return;
     }
-    this.lastKnownElements = applyToScene({
-      roots: this.roots(),
-      api: this.api,
-      getPrevElements: () => this.lastKnownElements,
-      editingGuard: this.editingGuard,
-    });
+    this.lastKnownElements = this.applyGuarded();
   }
 
   /** Detach every observer + subscription; no leaks on remount (FR-B-012). */
@@ -221,12 +245,13 @@ export {
   yMapToElement,
   boundElementsToYMap,
   yMapToBoundElements,
+  extraBoundTextIds,
   writeChangedKeys,
   diffBoundElements,
   deepEqual,
 } from "./schema";
 export { orderByIndex, keyBetween, keysBetween, repairIndices } from "./order";
-export { diffFiles, readFiles } from "./files";
+export { diffFiles, readFiles, referencedFileIds } from "./files";
 
 export type { ElementRecord, AppStateAllowKey } from "./schema";
 export type {

--- a/packages/yjs-binding/src/index.ts
+++ b/packages/yjs-binding/src/index.ts
@@ -1,0 +1,241 @@
+import type {
+  BinaryFileData,
+  ExcalidrawImperativeAPI,
+} from "@excalidraw/excalidraw/types";
+
+import { ELEMENTS, FILES, APPSTATE, BINDING_ORIGIN } from "./schema";
+import { areElementsSame, writeDiff } from "./diff";
+import { applyToScene } from "./apply";
+import { AwarenessRouter } from "./awareness";
+import { populateYDoc } from "./migrate";
+
+import type * as Y from "yjs";
+
+import type { ElementRecord } from "./schema";
+import type { EditingGuard } from "./apply";
+import type { EphemeralChannel } from "./awareness";
+import type { Awareness } from "y-protocols/awareness";
+import type { SceneJSON } from "./migrate";
+
+/**
+ * The minimal Excalidraw imperative API surface the binding drives. Declared as
+ * a `Pick` so tests can supply a lightweight stub and so the package does not
+ * couple to the full editor.
+ */
+export type BindingExcalidrawAPI = Pick<
+  ExcalidrawImperativeAPI,
+  | "updateScene"
+  | "getSceneElementsIncludingDeleted"
+  | "getFiles"
+  | "addFiles"
+  | "getAppState"
+  | "onChange"
+> &
+  Partial<
+    Pick<
+      ExcalidrawImperativeAPI,
+      "dispatchIncomingEmojiReaction" | "dispatchIncomingCountdownTimer"
+    >
+  >;
+
+export type WhiteboardBindingOptions = {
+  /** Optional y-protocols awareness for cursor/selection/idle routing. */
+  awareness?: Awareness;
+  /** Optional ephemeral channel for emoji/countdown/bounds (WS-D wires it). */
+  ephemeral?: EphemeralChannel;
+  /** Initial scene to seed an empty doc (initial load / migration). */
+  initialScene?: SceneJSON;
+  /** Returns the id of the element the local user is mid-editing, or null. */
+  editingGuard?: EditingGuard;
+};
+
+/**
+ * `WhiteboardBinding` owns the scene ↔ `Y.Doc` loop (data-model §9). It is
+ * transport-agnostic: constructed from a `Y.Doc`, an `ExcalidrawImperativeAPI`,
+ * and optional awareness — it opens no sockets and knows no server (FR-B-011).
+ * One instance per mounted editor; disposable via `destroy()` (FR-B-012).
+ */
+export class WhiteboardBinding {
+  readonly ydoc: Y.Doc;
+  readonly elementsMap: Y.Map<Y.Map<unknown>>;
+  readonly filesMap: Y.Map<BinaryFileData>;
+  readonly appStateMap: Y.Map<unknown>;
+  readonly awarenessRouter?: AwarenessRouter;
+
+  private readonly api: BindingExcalidrawAPI;
+  private readonly editingGuard?: EditingGuard;
+  private lastKnownElements: ElementRecord[] = [];
+  private unsubscribeOnChange?: () => void;
+  private readonly observeDeepHandler: (
+    events: Y.YEvent<Y.AbstractType<unknown>>[],
+    transaction: Y.Transaction,
+  ) => void;
+  private readonly filesObserveHandler: (
+    event: Y.YMapEvent<BinaryFileData>,
+    transaction: Y.Transaction,
+  ) => void;
+  private readonly appStateObserveHandler: (
+    event: Y.YMapEvent<unknown>,
+    transaction: Y.Transaction,
+  ) => void;
+  private destroyed = false;
+
+  constructor(
+    ydoc: Y.Doc,
+    api: BindingExcalidrawAPI,
+    options: WhiteboardBindingOptions = {},
+  ) {
+    this.ydoc = ydoc;
+    this.api = api;
+    this.editingGuard = options.editingGuard;
+
+    this.elementsMap = ydoc.getMap<Y.Map<unknown>>(ELEMENTS);
+    this.filesMap = ydoc.getMap<BinaryFileData>(FILES);
+    this.appStateMap = ydoc.getMap<unknown>(APPSTATE);
+
+    // Seed an empty doc from the initial scene (initial load / migration).
+    if (this.elementsMap.size === 0 && options.initialScene) {
+      populateYDoc(options.initialScene, ydoc);
+    }
+
+    if (options.awareness) {
+      this.awarenessRouter = new AwarenessRouter({
+        awareness: options.awareness,
+        api: {
+          updateScene: api.updateScene,
+          dispatchIncomingEmojiReaction:
+            api.dispatchIncomingEmojiReaction ?? (() => {}),
+          dispatchIncomingCountdownTimer:
+            api.dispatchIncomingCountdownTimer ?? (() => {}),
+        },
+        ephemeral: options.ephemeral,
+      });
+    }
+
+    // Apply the current doc state to the scene, seeding lastKnownElements.
+    this.lastKnownElements = applyToScene({
+      roots: this.roots(),
+      api,
+      getPrevElements: () => this.lastKnownElements,
+      editingGuard: this.editingGuard,
+    });
+
+    // observe → apply (echo-guarded)
+    this.observeDeepHandler = (_events, transaction) =>
+      this.onDocChange(transaction);
+    this.filesObserveHandler = (_event, transaction) =>
+      this.onDocChange(transaction);
+    this.appStateObserveHandler = (_event, transaction) =>
+      this.onDocChange(transaction);
+    this.elementsMap.observeDeep(this.observeDeepHandler);
+    this.filesMap.observe(this.filesObserveHandler);
+    this.appStateMap.observe(this.appStateObserveHandler);
+
+    // onChange → diff
+    this.unsubscribeOnChange = api.onChange((elements, appState, files) =>
+      this.onSceneChange(
+        elements as unknown as ElementRecord[],
+        appState as unknown as Record<string, unknown>,
+        files,
+      ),
+    );
+  }
+
+  private roots() {
+    return {
+      ydoc: this.ydoc,
+      elementsMap: this.elementsMap,
+      filesMap: this.filesMap,
+      appStateMap: this.appStateMap,
+    };
+  }
+
+  /** onChange → per-property Yjs write path (FR-B-002). */
+  private onSceneChange(
+    elements: ElementRecord[],
+    appState: Record<string, unknown>,
+    files: Parameters<Parameters<BindingExcalidrawAPI["onChange"]>[0]>[2],
+  ): void {
+    if (this.destroyed) {
+      return;
+    }
+    // Fast path: if no element changed by (id, version), only appState/files can
+    // differ — still route through writeDiff (which self-guards no-op writes).
+    const elementsUnchanged = areElementsSame(this.lastKnownElements, elements);
+    writeDiff(
+      this.roots(),
+      this.lastKnownElements,
+      elements,
+      appState as never,
+      files as never,
+    );
+    if (!elementsUnchanged) {
+      this.lastKnownElements = elements.map((el) => ({ ...el }));
+    }
+  }
+
+  /** Yjs observe → scene apply path, echo-guarded (FR-B-004). */
+  private onDocChange(transaction: Y.Transaction): void {
+    if (this.destroyed) {
+      return;
+    }
+    // Echo guard: ignore our own writes.
+    if (transaction.origin === BINDING_ORIGIN) {
+      return;
+    }
+    this.lastKnownElements = applyToScene({
+      roots: this.roots(),
+      api: this.api,
+      getPrevElements: () => this.lastKnownElements,
+      editingGuard: this.editingGuard,
+    });
+  }
+
+  /** Detach every observer + subscription; no leaks on remount (FR-B-012). */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.elementsMap.unobserveDeep(this.observeDeepHandler);
+    this.filesMap.unobserve(this.filesObserveHandler);
+    this.appStateMap.unobserve(this.appStateObserveHandler);
+    this.unsubscribeOnChange?.();
+    this.unsubscribeOnChange = undefined;
+    this.awarenessRouter?.destroy();
+    this.lastKnownElements = [];
+  }
+}
+
+export { populateYDoc, exportSceneJSON } from "./migrate";
+export { areElementsSame, writeDiff, writeAppState } from "./diff";
+export { applyToScene, buildElements, readAppState, nonDeleted } from "./apply";
+export { AwarenessRouter } from "./awareness";
+export {
+  ELEMENTS,
+  FILES,
+  APPSTATE,
+  APPSTATE_ALLOW_LIST,
+  BINDING_ORIGIN,
+  elementToYMap,
+  yMapToElement,
+  boundElementsToYMap,
+  yMapToBoundElements,
+  writeChangedKeys,
+  diffBoundElements,
+  deepEqual,
+} from "./schema";
+export { orderByIndex, keyBetween, keysBetween, repairIndices } from "./order";
+export { diffFiles, readFiles } from "./files";
+
+export type { ElementRecord, AppStateAllowKey } from "./schema";
+export type {
+  EphemeralChannel,
+  EphemeralEvent,
+  PointerPayload,
+  EmojiReactionPayload,
+  CountdownTimerPayload,
+  VisibleSceneBoundsPayload,
+} from "./awareness";
+export type { SceneJSON } from "./migrate";
+export type { EditingGuard } from "./apply";

--- a/packages/yjs-binding/src/migrate.ts
+++ b/packages/yjs-binding/src/migrate.ts
@@ -98,21 +98,50 @@ export const exportSceneJSON = (ydoc: Y.Doc): Required<SceneJSON> => {
 };
 
 /**
- * Assign provisional sequential indices to elements that have none, preserving
- * the source array order, before the deterministic `repairIndices` pass. This
- * keeps a source scene with entirely missing indices in its given order.
+ * Assign provisional fractional indices to elements that have none, preserving
+ * the source array order, before the deterministic `repairIndices` pass.
+ *
+ * A no-index element is seeded BETWEEN its nearest already-indexed (or
+ * already-seeded) neighbours in array order, so it keeps the z-position the
+ * source array implies. The previous implementation only seeded when EVERY
+ * element lacked an index; a PARTIAL-missing set was left with `null` indices,
+ * and `orderByIndex` sinks null-index elements to the end — so a front element
+ * with no index (e.g. `X, Y(no idx), Z` → `X, Z, Y`) was silently reordered to
+ * the back (Fix #4).
  */
 const seedMissingIndices = (elements: ElementRecord[]): void => {
-  const missingCount = elements.filter((el) => el.index == null).length;
-  if (missingCount === 0) {
-    return;
+  const n = elements.length;
+  let i = 0;
+  while (i < n) {
+    if (readIndexOf(elements[i]) != null) {
+      i++;
+      continue;
+    }
+    // contiguous run of missing indices [i, j)
+    let j = i;
+    while (j < n && readIndexOf(elements[j]) == null) {
+      j++;
+    }
+    const lower = i > 0 ? readIndexOf(elements[i - 1]) : null;
+    const upper = j < n ? readIndexOf(elements[j]) : null;
+    const runLength = j - i;
+    let keys: string[];
+    try {
+      keys = keysBetween(lower, upper, runLength);
+    } catch {
+      // Source bounds were not strictly increasing (malformed input). Seed above
+      // the lower bound only; `repairIndices` afterwards makes the order strictly
+      // increasing again. Preserves array order within the run.
+      keys = keysBetween(lower, null, runLength);
+    }
+    for (let k = 0; k < runLength; k++) {
+      elements[i + k].index = keys[k];
+    }
+    i = j;
   }
-  // If ALL are missing, distribute keys across the whole space in array order.
-  if (missingCount === elements.length) {
-    const keys = keysBetween(null, null, elements.length);
-    elements.forEach((el, i) => {
-      el.index = keys[i];
-    });
-  }
-  // Partial-missing is handled by repairIndices afterwards.
+};
+
+const readIndexOf = (el: ElementRecord): string | null => {
+  const idx = el.index;
+  return typeof idx === "string" ? idx : null;
 };

--- a/packages/yjs-binding/src/migrate.ts
+++ b/packages/yjs-binding/src/migrate.ts
@@ -1,0 +1,118 @@
+import type { BinaryFileData, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import {
+  ELEMENTS,
+  FILES,
+  APPSTATE,
+  APPSTATE_ALLOW_LIST,
+  BINDING_ORIGIN,
+  elementToYMap,
+  yMapToElement,
+} from "./schema";
+import { keysBetween, orderByIndex, repairIndices } from "./order";
+import { readFiles } from "./files";
+
+import type * as Y from "yjs";
+
+import type { ElementRecord } from "./schema";
+
+/**
+ * Lossless `Excalidraw-JSON ↔ Y.Doc` round-trip (FR-B-010, data-model §6). The
+ * WS-E migration consumes `populateYDoc`; this package owns its correctness, not
+ * its scheduling.
+ */
+
+export type SceneJSON = {
+  elements: ElementRecord[];
+  files?: BinaryFiles;
+  appState?: Record<string, unknown>;
+};
+
+/**
+ * Write every element (tombstones included) into the scene `Y.Map`, files into
+ * the files `Y.Map`, and the appState allow-list into the appState `Y.Map`.
+ * Missing/invalid `index` values are repaired (data-model §6 rule 3) — the only
+ * case where order may legitimately change vs a malformed source. Writes happen
+ * under `BINDING_ORIGIN` so a live binding does not echo the load.
+ */
+export const populateYDoc = (sceneJSON: SceneJSON, ydoc: Y.Doc): Y.Doc => {
+  const elementsMap = ydoc.getMap<Y.Map<unknown>>(ELEMENTS);
+  const filesMap = ydoc.getMap<BinaryFileData>(FILES);
+  const appStateMap = ydoc.getMap<unknown>(APPSTATE);
+
+  // Repair indices on a working copy first (pure), then seed the doc.
+  const working: ElementRecord[] = sceneJSON.elements.map((el) => ({ ...el }));
+  seedMissingIndices(working);
+  const { ordered } = repairIndices(working);
+
+  ydoc.transact(() => {
+    for (const element of ordered) {
+      elementsMap.set(element.id as string, elementToYMap(element));
+    }
+    if (sceneJSON.files) {
+      for (const [id, file] of Object.entries(sceneJSON.files)) {
+        filesMap.set(id, file);
+      }
+    }
+    if (sceneJSON.appState) {
+      for (const key of APPSTATE_ALLOW_LIST) {
+        const value = sceneJSON.appState[key];
+        if (value !== undefined) {
+          appStateMap.set(key, value);
+        }
+      }
+    }
+  }, BINDING_ORIGIN);
+
+  return ydoc;
+};
+
+/**
+ * Read the doc back into an Excalidraw scene (ordered by `index`), inverting
+ * `populateYDoc`. Tombstones are carried through unchanged.
+ */
+export const exportSceneJSON = (ydoc: Y.Doc): Required<SceneJSON> => {
+  const elementsMap = ydoc.getMap<Y.Map<unknown>>(ELEMENTS);
+  const filesMap = ydoc.getMap<BinaryFileData>(FILES);
+  const appStateMap = ydoc.getMap<unknown>(APPSTATE);
+
+  const elements: ElementRecord[] = [];
+  for (const [id, ymap] of elementsMap.entries()) {
+    const element = yMapToElement(ymap);
+    element.id = id;
+    elements.push(element);
+  }
+
+  const appState: Record<string, unknown> = {};
+  for (const key of APPSTATE_ALLOW_LIST) {
+    if (appStateMap.has(key)) {
+      appState[key] = appStateMap.get(key);
+    }
+  }
+
+  return {
+    elements: orderByIndex(elements),
+    files: readFiles(filesMap),
+    appState,
+  };
+};
+
+/**
+ * Assign provisional sequential indices to elements that have none, preserving
+ * the source array order, before the deterministic `repairIndices` pass. This
+ * keeps a source scene with entirely missing indices in its given order.
+ */
+const seedMissingIndices = (elements: ElementRecord[]): void => {
+  const missingCount = elements.filter((el) => el.index == null).length;
+  if (missingCount === 0) {
+    return;
+  }
+  // If ALL are missing, distribute keys across the whole space in array order.
+  if (missingCount === elements.length) {
+    const keys = keysBetween(null, null, elements.length);
+    elements.forEach((el, i) => {
+      el.index = keys[i];
+    });
+  }
+  // Partial-missing is handled by repairIndices afterwards.
+};

--- a/packages/yjs-binding/src/order.ts
+++ b/packages/yjs-binding/src/order.ts
@@ -1,0 +1,137 @@
+import {
+  generateKeyBetween,
+  generateNKeysBetween,
+} from "@excalidraw/fractional-indexing";
+
+/**
+ * Z-order primitives (data-model §3). These are thin wrappers over the fork's
+ * **pure**, vendored `@excalidraw/fractional-indexing` base-62 key generator —
+ * the same order-preserving scheme the editor uses — kept decoupled from the
+ * editor's heavier `fractionalIndex.ts` (which imports `mutateElement` /
+ * canvas machinery and mutates `version`/`versionNonce` as a side effect we must
+ * own ourselves per OPEN-3). We never invent an ordering scheme: keys are always
+ * produced by `generateKeyBetween` / `generateNKeysBetween`, and the collision
+ * repair mirrors the editor's `syncInvalidIndices` contract (deterministic,
+ * idempotent regeneration of indices that are not strictly increasing).
+ */
+
+/**
+ * The minimal shape the order helpers read. An `ElementRecord`
+ * (`Record<string, unknown>`) is structurally compatible, so callers pass plain
+ * element records without casts; the helpers coerce `id`/`index` internally.
+ */
+type Indexed = Record<string, unknown>;
+
+const readIndex = (el: Indexed): string | null => {
+  const idx = el.index;
+  return typeof idx === "string" ? idx : null;
+};
+
+const readId = (el: Indexed): string => {
+  const id = el.id;
+  return typeof id === "string" ? id : String(id);
+};
+
+/**
+ * Order elements by their fractional `index`, ties broken by `id` — identical
+ * semantics to the fork's `orderByFractionalIndex`. Pure: returns a new array,
+ * does not mutate the input.
+ */
+export const orderByIndex = <T extends Indexed>(
+  elements: readonly T[],
+): T[] => {
+  return [...elements].sort((a, b) => {
+    const ai = readIndex(a);
+    const bi = readIndex(b);
+    const aid = readId(a);
+    const bid = readId(b);
+    if (ai != null && bi != null) {
+      if (ai < bi) {
+        return -1;
+      }
+      if (ai > bi) {
+        return 1;
+      }
+      // equal index → break ties by id (matches the fork)
+      return aid < bid ? -1 : aid > bid ? 1 : 0;
+    }
+    // keep elements with a defined index ahead of those without, else stable
+    if (ai == null && bi == null) {
+      return aid < bid ? -1 : aid > bid ? 1 : 0;
+    }
+    return ai == null ? 1 : -1;
+  });
+};
+
+/** Generate a fractional key strictly between `prev` and `next` (either may be null). */
+export const keyBetween = (
+  prev: string | null | undefined,
+  next: string | null | undefined,
+): string => generateKeyBetween(prev ?? null, next ?? null);
+
+/** Generate `n` distinct fractional keys strictly between `prev` and `next`. */
+export const keysBetween = (
+  prev: string | null | undefined,
+  next: string | null | undefined,
+  n: number,
+): string[] => generateNKeysBetween(prev ?? null, next ?? null, n);
+
+/**
+ * Repair invalid / colliding fractional indices deterministically and
+ * idempotently — the binding's equivalent of `syncInvalidIndices` (data-model
+ * §3, US3-AC3). Two clients that concurrently insert at the same gap can pick the
+ * **same** index; on apply, the elements are first ordered (ties by id, so the
+ * resolution is identical on every replica), then any index that is not strictly
+ * greater than its predecessor is regenerated to sit strictly between its
+ * neighbours.
+ *
+ * Mutates the `index` field of the affected elements in place and returns the set
+ * of element ids whose `index` was changed (so the caller can persist the repair
+ * back into the doc under `BINDING_ORIGIN`). Running it again on a repaired array
+ * is a no-op (idempotent).
+ */
+export const repairIndices = <T extends Indexed>(
+  elements: readonly T[],
+): { ordered: T[]; repaired: Set<string> } => {
+  const ordered = orderByIndex(elements);
+  const repaired = new Set<string>();
+
+  // `accepted` is the last index we have accepted as valid (the lower bound for
+  // the next gap). It starts null (before the first element).
+  let accepted: string | null = null;
+  let i = 0;
+  while (i < ordered.length) {
+    const current = readIndex(ordered[i]);
+
+    // Valid iff present and strictly greater than the last accepted index.
+    if (current != null && current > (accepted ?? "")) {
+      accepted = current;
+      i++;
+      continue;
+    }
+
+    // Collect the contiguous run of invalid elements [i, j): each is missing or
+    // not strictly greater than the index that precedes it within the run.
+    let j = i;
+    let runPrev = accepted;
+    while (j < ordered.length) {
+      const candidate = readIndex(ordered[j]);
+      if (candidate != null && candidate > (runPrev ?? "")) {
+        break; // first valid element after the run → the upper bound
+      }
+      runPrev = candidate;
+      j++;
+    }
+
+    const upper = j < ordered.length ? readIndex(ordered[j]) : null;
+    const keys = keysBetween(accepted, upper, j - i);
+    for (let k = i; k < j; k++) {
+      (ordered[k] as Record<string, unknown>).index = keys[k - i];
+      repaired.add(readId(ordered[k]));
+    }
+    accepted = keys[keys.length - 1] ?? accepted;
+    i = j;
+  }
+
+  return { ordered, repaired };
+};

--- a/packages/yjs-binding/src/origin.ts
+++ b/packages/yjs-binding/src/origin.ts
@@ -1,0 +1,19 @@
+/**
+ * The binding's transaction-origin sentinel.
+ *
+ * Every Yjs write the binding performs is wrapped in
+ * `ydoc.transact(fn, BINDING_ORIGIN)`. The observe/observeDeep handlers
+ * short-circuit when `transaction.origin === BINDING_ORIGIN`, which is how the
+ * binding ignores its own writes and avoids a re-entrant `updateScene` feedback
+ * loop (FR-B-004, the echo guard).
+ *
+ * It is a unique, opaque object — identity is the only thing that matters, so it
+ * is compared by reference. One module-level singleton is shared by every helper
+ * so a write made in `diff.ts` is recognised as "ours" by the observer in
+ * `apply.ts`.
+ */
+export const BINDING_ORIGIN: { readonly name: "alkemio-yjs-binding" } = {
+  name: "alkemio-yjs-binding",
+};
+
+export type BindingOrigin = typeof BINDING_ORIGIN;

--- a/packages/yjs-binding/src/schema.ts
+++ b/packages/yjs-binding/src/schema.ts
@@ -1,0 +1,300 @@
+import * as Y from "yjs";
+
+import type { BoundElement } from "@excalidraw/element/types";
+
+import { BINDING_ORIGIN } from "./origin";
+
+/**
+ * Top-level Yjs root-type names (obtained via `ydoc.getMap(name)`).
+ * See data-model §1.
+ */
+export const ELEMENTS = "elements" as const;
+export const FILES = "files" as const;
+export const APPSTATE = "appState" as const;
+
+/**
+ * The `appState` allow-list synced through the `APPSTATE` `Y.Map` (OPEN-2
+ * resolved). Everything else in Excalidraw's appState stays per-client
+ * (selection, zoom, scroll, active tool) and is NEVER written to the doc.
+ */
+export const APPSTATE_ALLOW_LIST = ["viewBackgroundColor", "name"] as const;
+export type AppStateAllowKey = typeof APPSTATE_ALLOW_LIST[number];
+
+/**
+ * Representation tiering (data-model §4).
+ *
+ * - **scalars** → plain `Y.Map` value (number / string / boolean / null).
+ * - **JSON-leaf** → stored as the whole value (object/array) directly as the Yjs
+ *   value; compared by deep value-equality; per-key LWW for the whole blob.
+ * - **`boundElements`** → the single nested `Y.Map<id, "arrow"|"text">` add/remove
+ *   set (§4.1), the only nested Y type in v1.
+ *
+ * Keys NOT listed here are scalars. The set is derived from the live element via
+ * `Object.keys` (so new upstream scalar fields carry automatically); only the
+ * non-scalar keys need explicit classification.
+ */
+export const JSON_LEAF_KEYS: ReadonlySet<string> = new Set([
+  "points",
+  "pressures",
+  "groupIds",
+  "roundness",
+  "startBinding",
+  "endBinding",
+  "fixedSegments",
+  "scale",
+  "crop",
+  "customData",
+]);
+
+export const BOUND_ELEMENTS_KEY = "boundElements" as const;
+
+export type BoundElementType = BoundElement["type"];
+
+/** A plain element record as it travels through the binding (mutable copy). */
+export type ElementRecord = Record<string, unknown>;
+
+/**
+ * Deep value-equality used for the JSON-leaf diff. Order-sensitive for arrays and
+ * key-order-insensitive for objects (so it does not depend on the non-canonical
+ * JSON byte form — research §5 / data-model §4). `undefined` and a missing key
+ * compare equal.
+ */
+export const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || b === null || a === undefined || b === undefined) {
+    // already handled strict-equal above; only one side is nullish here
+    return a == null && b == null;
+  }
+  if (typeof a !== "object" || typeof b !== "object") {
+    return false;
+  }
+  const aIsArr = Array.isArray(a);
+  const bIsArr = Array.isArray(b);
+  if (aIsArr !== bIsArr) {
+    return false;
+  }
+  if (aIsArr && bIsArr) {
+    if (a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bObj, key)) {
+      return false;
+    }
+    if (!deepEqual(aObj[key], bObj[key])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/** A structured-clone style deep copy of a JSON-able value (no shared refs). */
+const cloneJSON = <T>(value: T): T => {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+/**
+ * Encode an element's `boundElements` array into a fresh nested `Y.Map` (§4.1).
+ * Key = bound id, value = "arrow"|"text". Order is dropped (the fork consumes
+ * `boundElements` via `arrayToMap`/`.find`/`.filter`, so order is not semantic).
+ */
+export const boundElementsToYMap = (
+  boundElements: readonly BoundElement[] | null | undefined,
+): Y.Map<BoundElementType> => {
+  const map = new Y.Map<BoundElementType>();
+  if (boundElements) {
+    for (const bound of boundElements) {
+      map.set(bound.id, bound.type);
+    }
+  }
+  return map;
+};
+
+/**
+ * Materialize the nested `boundElements` `Y.Map` back into a `BoundElement[]`
+ * array (§4.1), applying the "at most one bound text" invariant deterministically
+ * on read: if concurrency produced more than one `type:"text"` key, keep the
+ * lowest id and drop the extra text bindings. Returns `null` for an empty map so
+ * the round-trip matches Excalidraw's `boundElements: null` convention.
+ */
+export const yMapToBoundElements = (
+  map: Y.Map<BoundElementType> | undefined,
+): BoundElement[] | null => {
+  if (!map || map.size === 0) {
+    return null;
+  }
+  const entries: BoundElement[] = [];
+  for (const [id, type] of map.entries()) {
+    entries.push({ id, type });
+  }
+  // Deterministic order independent of Y.Map insertion order, so every replica
+  // materializes an identical array (ties already unique by id).
+  entries.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  // "at most one bound text" — keep the lowest id, drop extra text bindings.
+  const textIds = entries.filter((e) => e.type === "text").map((e) => e.id);
+  if (textIds.length > 1) {
+    const keep = textIds[0]; // entries already sorted by id → lowest first
+    return entries.filter((e) => e.type !== "text" || e.id === keep);
+  }
+  return entries;
+};
+
+/**
+ * Encode a plain Excalidraw element into a fresh per-element `Y.Map` honoring the
+ * representation tiering (T003). Keys are derived from the live object via
+ * `Object.keys`, so new upstream scalar fields carry automatically.
+ *
+ * - `boundElements` → nested `Y.Map` (§4.1).
+ * - JSON-leaf keys → the value stored directly (deep-cloned to avoid shared refs).
+ * - everything else → the scalar value as-is.
+ */
+export const elementToYMap = (element: ElementRecord): Y.Map<unknown> => {
+  const ymap = new Y.Map<unknown>();
+  for (const key of Object.keys(element)) {
+    const value = element[key];
+    if (value === undefined) {
+      // Excalidraw omits some optional keys (e.g. customData) — don't store
+      // `undefined`, which Yjs treats as a delete and which breaks round-trip
+      // "missing key" symmetry.
+      continue;
+    }
+    if (key === BOUND_ELEMENTS_KEY) {
+      ymap.set(
+        key,
+        boundElementsToYMap(value as readonly BoundElement[] | null),
+      );
+    } else if (JSON_LEAF_KEYS.has(key)) {
+      ymap.set(key, cloneJSON(value));
+    } else {
+      ymap.set(key, value);
+    }
+  }
+  return ymap;
+};
+
+/**
+ * Decode a per-element `Y.Map` back into a plain Excalidraw element record
+ * (T003), inverting `elementToYMap`. JSON-leaf values are deep-cloned so the
+ * returned object never aliases doc-internal data; `boundElements` is
+ * materialized from its nested `Y.Map`.
+ */
+export const yMapToElement = (ymap: Y.Map<unknown>): ElementRecord => {
+  const element: ElementRecord = {};
+  for (const [key, value] of ymap.entries()) {
+    if (key === BOUND_ELEMENTS_KEY) {
+      element[key] = yMapToBoundElements(value as Y.Map<BoundElementType>);
+    } else if (JSON_LEAF_KEYS.has(key)) {
+      element[key] = cloneJSON(value);
+    } else {
+      element[key] = value;
+    }
+  }
+  return element;
+};
+
+/**
+ * Write the changed per-property keys of `element` into an existing element
+ * `Y.Map` (the diff write path, §8). Only keys whose value actually changed are
+ * written:
+ *
+ * - scalars: strict `!==`.
+ * - JSON-leaf: `!deepEqual`, value re-stored whole (per-key LWW for the blob).
+ * - `boundElements`: diffed into the nested `Y.Map` via `set(id,type)` /
+ *   `delete(id)` (§4.1) — add/remove set, never whole-array replace.
+ *
+ * Keys present on the `Y.Map` but absent from the element are NOT deleted here
+ * (deletes are tombstones via `isDeleted`, not key removal — FR-B-006).
+ *
+ * MUST be called inside a `ydoc.transact(fn, BINDING_ORIGIN)`. Returns the number
+ * of keys written (0 ⇒ nothing changed).
+ */
+export const writeChangedKeys = (
+  ymap: Y.Map<unknown>,
+  element: ElementRecord,
+): number => {
+  let writes = 0;
+  for (const key of Object.keys(element)) {
+    const next = element[key];
+    if (next === undefined) {
+      continue;
+    }
+    if (key === BOUND_ELEMENTS_KEY) {
+      writes += diffBoundElements(ymap, next as readonly BoundElement[] | null);
+      continue;
+    }
+    const prev = ymap.get(key);
+    if (JSON_LEAF_KEYS.has(key)) {
+      if (!deepEqual(prev, next)) {
+        ymap.set(key, cloneJSON(next));
+        writes++;
+      }
+    } else if (prev !== next) {
+      ymap.set(key, next);
+      writes++;
+    }
+  }
+  return writes;
+};
+
+/**
+ * Diff the element's `boundElements` array against the nested `Y.Map`, applying
+ * `set`/`delete` for the delta only (§4.1). MUST run inside a
+ * `BINDING_ORIGIN` transaction. Returns the number of mutations applied.
+ */
+export const diffBoundElements = (
+  parent: Y.Map<unknown>,
+  boundElements: readonly BoundElement[] | null,
+): number => {
+  let nested = parent.get(BOUND_ELEMENTS_KEY) as
+    | Y.Map<BoundElementType>
+    | undefined;
+  if (!(nested instanceof Y.Map)) {
+    // No nested map yet (or a non-map legacy value) — install a fresh one.
+    nested = new Y.Map<BoundElementType>();
+    parent.set(BOUND_ELEMENTS_KEY, nested);
+  }
+  const next = new Map<string, BoundElementType>();
+  if (boundElements) {
+    for (const bound of boundElements) {
+      next.set(bound.id, bound.type);
+    }
+  }
+  let mutations = 0;
+  // Removes: ids in the map but not in the next array.
+  for (const id of [...nested.keys()]) {
+    if (!next.has(id)) {
+      nested.delete(id);
+      mutations++;
+    }
+  }
+  // Adds / type changes: ids in the next array with a new or changed type.
+  for (const [id, type] of next) {
+    if (nested.get(id) !== type) {
+      nested.set(id, type);
+      mutations++;
+    }
+  }
+  return mutations;
+};
+
+export { BINDING_ORIGIN };

--- a/packages/yjs-binding/src/schema.ts
+++ b/packages/yjs-binding/src/schema.ts
@@ -48,6 +48,24 @@ export const JSON_LEAF_KEYS: ReadonlySet<string> = new Set([
 
 export const BOUND_ELEMENTS_KEY = "boundElements" as const;
 
+/**
+ * Excalidraw reconciliation metadata that each peer derives **locally** and that
+ * is therefore NEVER synced through the doc (OPEN-3, echo-loop fix). If these
+ * round-tripped as ordinary LWW scalars, a remote apply would mint a fresh
+ * `versionNonce`/`updated`, write them back under `BINDING_ORIGIN`, broadcast,
+ * and every peer would re-mint them — an unbounded cross-replica ping-pong.
+ *
+ * They are excluded from every write path (`elementToYMap`, `writeChangedKeys`),
+ * ignored as change signals (`elementChanged`/`hasDiffWork`), and re-derived on
+ * apply (`bumpVersion`) from local doc state — deterministically, so re-applying
+ * the same doc state is idempotent (no `Math.random()`/`Date.now()`).
+ */
+export const RECONCILE_META_KEYS: ReadonlySet<string> = new Set([
+  "version",
+  "versionNonce",
+  "updated",
+]);
+
 export type BoundElementType = BoundElement["type"];
 
 /** A plain element record as it travels through the binding (mutable copy). */
@@ -160,6 +178,32 @@ export const yMapToBoundElements = (
 };
 
 /**
+ * Given a nested `boundElements` `Y.Map`, return the ids of the *extra* text
+ * bindings that violate the "at most one bound text" invariant — every
+ * `type:"text"` entry except the lowest id (the keeper). Empty when the
+ * invariant already holds. Deterministic on every replica (sorts by id), so the
+ * reconciliation it drives converges without flapping (Fix #6).
+ */
+export const extraBoundTextIds = (
+  map: Y.Map<BoundElementType> | undefined,
+): string[] => {
+  if (!map || map.size === 0) {
+    return [];
+  }
+  const textIds: string[] = [];
+  for (const [id, type] of map.entries()) {
+    if (type === "text") {
+      textIds.push(id);
+    }
+  }
+  if (textIds.length <= 1) {
+    return [];
+  }
+  textIds.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  return textIds.slice(1); // keep the lowest id, the rest are extra
+};
+
+/**
  * Encode a plain Excalidraw element into a fresh per-element `Y.Map` honoring the
  * representation tiering (T003). Keys are derived from the live object via
  * `Object.keys`, so new upstream scalar fields carry automatically.
@@ -171,6 +215,11 @@ export const yMapToBoundElements = (
 export const elementToYMap = (element: ElementRecord): Y.Map<unknown> => {
   const ymap = new Y.Map<unknown>();
   for (const key of Object.keys(element)) {
+    if (RECONCILE_META_KEYS.has(key)) {
+      // version/versionNonce/updated are per-peer reconciliation metadata, never
+      // synced — each replica derives them locally on apply (OPEN-3).
+      continue;
+    }
     const value = element[key];
     if (value === undefined) {
       // Excalidraw omits some optional keys (e.g. customData) — don't store
@@ -222,8 +271,14 @@ export const yMapToElement = (ymap: Y.Map<unknown>): ElementRecord => {
  * - `boundElements`: diffed into the nested `Y.Map` via `set(id,type)` /
  *   `delete(id)` (§4.1) — add/remove set, never whole-array replace.
  *
- * Keys present on the `Y.Map` but absent from the element are NOT deleted here
- * (deletes are tombstones via `isDeleted`, not key removal — FR-B-006).
+ * A property going value → absent on the element (e.g. `link` cleared to
+ * `undefined`, or the key dropped entirely) IS removed from the `Y.Map` so a
+ * stale value cannot resurrect on the next round-trip (clear semantics). Element
+ * *removal* is still a tombstone via `isDeleted`, never wholesale key removal
+ * (FR-B-006) — this only clears individual properties of a surviving element.
+ *
+ * `version`/`versionNonce`/`updated` are never written here (per-peer
+ * reconciliation metadata — `RECONCILE_META_KEYS`, OPEN-3).
  *
  * MUST be called inside a `ydoc.transact(fn, BINDING_ORIGIN)`. Returns the number
  * of keys written (0 ⇒ nothing changed).
@@ -234,8 +289,19 @@ export const writeChangedKeys = (
 ): number => {
   let writes = 0;
   for (const key of Object.keys(element)) {
+    if (RECONCILE_META_KEYS.has(key)) {
+      continue;
+    }
     const next = element[key];
     if (next === undefined) {
+      // value → absent: clear it from the doc so it can't resurrect. boundElements
+      // is handled below via diffBoundElements (which empties the nested map).
+      if (key !== BOUND_ELEMENTS_KEY && ymap.has(key)) {
+        ymap.delete(key);
+        writes++;
+      } else if (key === BOUND_ELEMENTS_KEY) {
+        writes += diffBoundElements(ymap, null);
+      }
       continue;
     }
     if (key === BOUND_ELEMENTS_KEY) {
@@ -250,6 +316,20 @@ export const writeChangedKeys = (
       }
     } else if (prev !== next) {
       ymap.set(key, next);
+      writes++;
+    }
+  }
+  // Keys present on the doc but entirely absent from the element object (the key
+  // was dropped, not set to undefined) — clear them too (excluding meta + the
+  // element id, which is the map key, not a stored property).
+  for (const key of [...ymap.keys()]) {
+    if (
+      key !== "id" &&
+      key !== BOUND_ELEMENTS_KEY &&
+      !RECONCILE_META_KEYS.has(key) &&
+      !Object.prototype.hasOwnProperty.call(element, key)
+    ) {
+      ymap.delete(key);
       writes++;
     }
   }

--- a/packages/yjs-binding/tests/apply-order.test.ts
+++ b/packages/yjs-binding/tests/apply-order.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  StubExcalidrawAPI,
+  WhiteboardBinding,
+  Y,
+  makeElement,
+  sync,
+} from "./helpers";
+
+import type { ElementRecord } from "../src/schema";
+
+const setup = () => {
+  const docA = new Y.Doc();
+  const docB = new Y.Doc();
+  const apiA = new StubExcalidrawAPI();
+  const apiB = new StubExcalidrawAPI();
+  const bindingA = new WhiteboardBinding(docA, apiA.asBindingAPI());
+  const bindingB = new WhiteboardBinding(docB, apiB.asBindingAPI());
+  return { docA, docB, apiA, apiB, bindingA, bindingB };
+};
+
+const ids = (api: StubExcalidrawAPI): string[] =>
+  api.elements.map((e) => e.id as string);
+
+describe("apply: remote insert order (US3-AC1)", () => {
+  it("a remote insert between two elements renders in correct z-position", () => {
+    const { docA, docB, apiA, apiB, bindingA, bindingB } = setup();
+
+    apiA.emitChange([
+      makeElement({ id: "a", index: "a1" }),
+      makeElement({ id: "c", index: "a3" }),
+    ]);
+    sync(docA, docB);
+    expect(ids(apiB)).toEqual(["a", "c"]);
+
+    // B inserts "b" between them (gives it an index between a1 and a3).
+    apiB.emitChange([
+      apiB.elements[0],
+      { ...makeElement({ id: "b", index: "a2" }) },
+      apiB.elements[1],
+    ]);
+    sync(docA, docB);
+
+    expect(ids(apiA)).toEqual(["a", "b", "c"]);
+    expect(ids(apiB)).toEqual(["a", "b", "c"]);
+
+    bindingA.destroy();
+    bindingB.destroy();
+  });
+});
+
+describe("apply: tombstone filter (US3-AC2)", () => {
+  it("a remote isDeleted=true element is absent from the rendered scene", () => {
+    const { docA, docB, apiA, apiB, bindingA, bindingB } = setup();
+
+    apiA.emitChange([
+      makeElement({ id: "keep", index: "a1" }),
+      makeElement({ id: "gone", index: "a2" }),
+    ]);
+    sync(docA, docB);
+
+    // A deletes "gone".
+    apiA.emitChange([apiA.elements[0]]); // gone removed from array → tombstone
+    sync(docA, docB);
+
+    // Rendered (non-deleted) set on B excludes the tombstone.
+    const rendered = apiB.elements.filter((e) => e.isDeleted !== true);
+    expect(rendered.map((e) => e.id)).toEqual(["keep"]);
+
+    // But the tombstone is retained in B's doc.
+    const docMap = docB.getMap<Y.Map<unknown>>("elements");
+    expect(docMap.get("gone")!.get("isDeleted")).toBe(true);
+
+    bindingA.destroy();
+    bindingB.destroy();
+  });
+});
+
+describe("apply: concurrent equal-index repair (T029 / US3-AC3)", () => {
+  it("two clients inserting at the same gap converge to identical order", () => {
+    const { docA, docB, apiA, apiB, bindingA, bindingB } = setup();
+
+    // Shared baseline of two elements.
+    apiA.emitChange([
+      makeElement({ id: "base1", index: "a1" }),
+      makeElement({ id: "base2", index: "a3" }),
+    ]);
+    sync(docA, docB);
+
+    // A and B each insert a NEW element that picks the SAME index "a2"
+    // (simulating the concurrent same-gap insert).
+    apiA.emitChange([
+      apiA.elements[0],
+      makeElement({ id: "fromA", index: "a2" }),
+      apiA.elements[1],
+    ]);
+    apiB.emitChange([
+      apiB.elements[0],
+      makeElement({ id: "fromB", index: "a2" }),
+      apiB.elements[1],
+    ]);
+
+    sync(docA, docB);
+
+    // Both converge to identical order after repairIndices.
+    expect(ids(apiA)).toEqual(ids(apiB));
+    // base1 first, base2 last; the two colliders in the middle, deterministic.
+    expect(ids(apiA)[0]).toBe("base1");
+    expect(ids(apiA)[3]).toBe("base2");
+    expect(ids(apiA).slice(1, 3).sort()).toEqual(["fromA", "fromB"]);
+
+    // And the indices are now strictly increasing on both.
+    for (const api of [apiA, apiB]) {
+      const indices = api.elements.map((e) => e.index as string);
+      const sorted = [...indices].sort();
+      expect(indices).toEqual(sorted);
+      expect(new Set(indices).size).toBe(indices.length); // no dupes
+    }
+
+    bindingA.destroy();
+    bindingB.destroy();
+  });
+});
+
+describe("apply: editing guard (FR-B-013)", () => {
+  it("does not replace an element the local user is mid-editing", () => {
+    const doc = new Y.Doc();
+    const remote = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    let editingId: string | null = null;
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      editingGuard: () => editingId,
+    });
+
+    api.emitChange([makeElement({ id: "edit-me", x: 0, index: "a1" })]);
+    sync(doc, remote);
+
+    // User starts editing "edit-me" locally (local x = 500, not yet in doc).
+    editingId = "edit-me";
+    const localEditing: ElementRecord = { ...api.elements[0], x: 500 };
+    api.elements = [localEditing];
+
+    // A remote update changes the same element's x to 999.
+    const rmap = remote.getMap<Y.Map<unknown>>("elements");
+    remote.transact(() => {
+      rmap.get("edit-me")!.set("x", 999);
+      rmap.get("edit-me")!.set("version", 99);
+    });
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote));
+
+    // The guard kept the local mid-edit copy (x = 500), not the remote (999).
+    expect(api.elements.find((e) => e.id === "edit-me")!.x).toBe(500);
+
+    binding.destroy();
+  });
+});

--- a/packages/yjs-binding/tests/awareness.test.ts
+++ b/packages/yjs-binding/tests/awareness.test.ts
@@ -1,0 +1,150 @@
+import { Awareness } from "y-protocols/awareness";
+import { describe, expect, it } from "vitest";
+
+import { AwarenessRouter } from "../src/awareness";
+import { BINDING_ORIGIN } from "../src/origin";
+
+import {
+  StubExcalidrawAPI,
+  WhiteboardBinding,
+  Y,
+  makeElement,
+} from "./helpers";
+
+import type { EphemeralChannel, EphemeralEvent } from "../src/awareness";
+
+/** A simple in-process ephemeral channel (the WS-D seam, stubbed). */
+const makeChannel = () => {
+  const handlers = new Set<(e: EphemeralEvent) => void>();
+  const sent: EphemeralEvent[] = [];
+  const channel: EphemeralChannel = {
+    send: (event) => {
+      sent.push(event);
+      for (const h of handlers) {
+        h(event);
+      }
+    },
+    subscribe: (handler) => {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+  };
+  return { channel, sent };
+};
+
+describe("awareness: ephemeral isolation (T022 / SC-B-004 / FR-B-008)", () => {
+  it("pointer/emoji/countdown produce ZERO scene-doc transactions", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    // seed one element so the scene is non-empty
+    api.emitChange([makeElement({ id: "x", index: "a1" })]);
+
+    const awareness = new Awareness(new Y.Doc());
+    const { channel } = makeChannel();
+    const router = new AwarenessRouter({
+      awareness,
+      api: api.routerApi(),
+      ephemeral: channel,
+    });
+
+    // Snapshot the scene doc, then fire a burst of ephemeral events.
+    const before = Y.encodeStateAsUpdate(doc);
+    let sceneTxns = 0;
+    doc.on("afterTransaction", () => {
+      sceneTxns++;
+    });
+
+    for (let i = 0; i < 10; i++) {
+      router.onPointerUpdate({
+        pointer: { x: i, y: i },
+        button: "up",
+      });
+    }
+    router.broadcastEmojiReaction({ id: "e1", emoji: "🎉", x: 1, y: 2 });
+    router.broadcastCountdownTimer({
+      remainingSeconds: 30,
+      startedBy: "u1",
+      active: true,
+    });
+    router.broadcastVisibleSceneBounds({ sceneBounds: [0, 0, 100, 100] });
+
+    expect(sceneTxns).toBe(0);
+
+    // Scene snapshot is byte-identical before/after the ephemeral burst.
+    const after = Y.encodeStateAsUpdate(doc);
+    expect(Buffer.from(after).equals(Buffer.from(before))).toBe(true);
+
+    router.destroy();
+    binding.destroy();
+  });
+
+  it("incoming ephemeral events dispatch to the editor's imperative API", () => {
+    const api = new StubExcalidrawAPI();
+    const awareness = new Awareness(new Y.Doc());
+    const { channel } = makeChannel();
+    const router = new AwarenessRouter({
+      awareness,
+      api: api.routerApi(),
+      ephemeral: channel,
+    });
+
+    router.broadcastEmojiReaction({ id: "e9", emoji: "👍", x: 5, y: 6 });
+    router.broadcastCountdownTimer({
+      remainingSeconds: 10,
+      startedBy: "u2",
+      active: true,
+    });
+
+    expect(api.dispatchedEmoji).toHaveLength(1);
+    expect(api.dispatchedEmoji[0]).toMatchObject({ emoji: "👍" });
+    expect(api.dispatchedCountdown).toHaveLength(1);
+
+    router.destroy();
+  });
+
+  it("remote awareness becomes collaborators via updateScene (no element mutation)", () => {
+    const api = new StubExcalidrawAPI();
+    const localAwareness = new Awareness(new Y.Doc());
+    const router = new AwarenessRouter({
+      awareness: localAwareness,
+      api: api.routerApi(),
+    });
+
+    const elementsBefore = api.elements.length;
+    // Simulate a remote peer's awareness state landing locally.
+    localAwareness.setLocalStateField("pointer", { x: 1, y: 1 });
+
+    const lastUpdate = api.updateSceneCalls[api.updateSceneCalls.length - 1];
+    expect(lastUpdate.collaborators).toBeDefined();
+    expect(lastUpdate.elements).toBeUndefined(); // no element mutation
+    expect(api.elements.length).toBe(elementsBefore);
+
+    router.destroy();
+  });
+});
+
+describe("awareness: the WhiteboardBinding never routes ephemeral into the doc", () => {
+  it("constructing with awareness leaves the scene doc free of presence keys", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const awareness = new Awareness(doc);
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      awareness,
+    });
+
+    api.emitChange([makeElement({ id: "z", index: "a1" })]);
+    awareness.setLocalStateField("pointer", { x: 9, y: 9 });
+
+    // The only roots in the doc are elements/files/appState — never "awareness"
+    // or "pointer" or "collaborators".
+    const ymap = doc.getMap<Y.Map<unknown>>("elements").get("z")!;
+    expect(ymap.has("pointer")).toBe(false);
+    expect(ymap.has("selectedElementIds")).toBe(false);
+    expect([...ymap.keys()]).not.toContain("collaborators");
+
+    binding.destroy();
+    void BINDING_ORIGIN;
+  });
+});

--- a/packages/yjs-binding/tests/awareness.test.ts
+++ b/packages/yjs-binding/tests/awareness.test.ts
@@ -1,4 +1,8 @@
-import { Awareness } from "y-protocols/awareness";
+import {
+  Awareness,
+  applyAwarenessUpdate,
+  encodeAwarenessUpdate,
+} from "y-protocols/awareness";
 import { describe, expect, it } from "vitest";
 
 import { AwarenessRouter } from "../src/awareness";
@@ -113,15 +117,63 @@ describe("awareness: ephemeral isolation (T022 / SC-B-004 / FR-B-008)", () => {
     });
 
     const elementsBefore = api.elements.length;
-    // Simulate a remote peer's awareness state landing locally.
-    localAwareness.setLocalStateField("pointer", { x: 1, y: 1 });
+    const callsBefore = api.updateSceneCalls.length;
 
+    // A genuinely REMOTE peer's awareness state lands locally (non-'local'
+    // origin) — encode a second awareness and apply it onto the local one.
+    const remoteAwareness = new Awareness(new Y.Doc());
+    remoteAwareness.setLocalStateField("pointer", { x: 1, y: 1 });
+    remoteAwareness.setLocalStateField("user", { username: "peer" });
+    applyAwarenessUpdate(
+      localAwareness,
+      encodeAwarenessUpdate(remoteAwareness, [remoteAwareness.clientID]),
+      "remote",
+    );
+
+    expect(api.updateSceneCalls.length).toBeGreaterThan(callsBefore);
     const lastUpdate = api.updateSceneCalls[api.updateSceneCalls.length - 1];
     expect(lastUpdate.collaborators).toBeDefined();
     expect(lastUpdate.elements).toBeUndefined(); // no element mutation
     expect(api.elements.length).toBe(elementsBefore);
 
     router.destroy();
+    remoteAwareness.destroy();
+  });
+
+  it("LOCAL-origin awareness changes do NOT trigger updateScene (Fix #7)", () => {
+    const api = new StubExcalidrawAPI();
+    const localAwareness = new Awareness(new Y.Doc());
+    const router = new AwarenessRouter({
+      awareness: localAwareness,
+      api: api.routerApi(),
+    });
+
+    const callsBefore = api.updateSceneCalls.length;
+    // Local cursor/selection moves — must not loop through applyRemoteAwareness.
+    router.onPointerUpdate({ pointer: { x: 5, y: 5 }, button: "up" });
+    router.onSelectionChange({ a: true });
+    router.onIdleChange("active");
+    localAwareness.setLocalStateField("pointer", { x: 9, y: 9 });
+
+    expect(api.updateSceneCalls.length).toBe(callsBefore);
+
+    router.destroy();
+  });
+
+  it("destroy() clears local awareness state so peers drop the cursor (Fix #7)", () => {
+    const api = new StubExcalidrawAPI();
+    const localAwareness = new Awareness(new Y.Doc());
+    const router = new AwarenessRouter({
+      awareness: localAwareness,
+      api: api.routerApi(),
+    });
+
+    router.onPointerUpdate({ pointer: { x: 1, y: 2 }, button: "up" });
+    expect(localAwareness.getLocalState()).not.toBeNull();
+
+    router.destroy();
+    // No ghost cursor: our local presence is cleared on teardown.
+    expect(localAwareness.getLocalState()).toBeNull();
   });
 });
 

--- a/packages/yjs-binding/tests/diff-direct.test.ts
+++ b/packages/yjs-binding/tests/diff-direct.test.ts
@@ -50,6 +50,29 @@ describe("writeDiff: new element index generation (findPrev/findNext)", () => {
     expect(bIndex < "a3").toBe(true);
   });
 
+  it("does NOT throw / abort the write when the input array is not index-sorted (Fix #8)", () => {
+    const roots = makeRoots();
+    // An unsorted onChange: descending indices around an indexless insert. Before
+    // the fix, generateKeyBetween(prev,next) with prev>=next threw and aborted
+    // the ENTIRE write, losing every element.
+    const next: ElementRecord[] = [
+      makeElement({ id: "hi", index: "a3" }),
+      makeElement({ id: "mid", index: null }), // insert between a3 and a1 (descending)
+      makeElement({ id: "lo", index: "a1" }),
+    ];
+    let writes = 0;
+    expect(() => {
+      writes = writeDiff(roots, [], next);
+    }).not.toThrow();
+    expect(writes).toBeGreaterThan(0);
+    // All three elements were written — none lost to an aborted transaction.
+    expect(roots.elementsMap.has("hi")).toBe(true);
+    expect(roots.elementsMap.has("mid")).toBe(true);
+    expect(roots.elementsMap.has("lo")).toBe(true);
+    // the indexless insert got SOME valid fractional key
+    expect(typeof roots.elementsMap.get("mid")!.get("index")).toBe("string");
+  });
+
   it("generates indices for a fully-indexless batch", () => {
     const roots = makeRoots();
     writeDiff(
@@ -69,7 +92,7 @@ describe("writeDiff: new element index generation (findPrev/findNext)", () => {
 });
 
 describe("writeDiff: removal → tombstone (FR-B-006)", () => {
-  it("sets isDeleted=true and bumps version, never deletes the map entry", () => {
+  it("sets isDeleted=true, never deletes the map entry, never syncs version (Fix #1/#5)", () => {
     const roots = makeRoots();
     const el = makeElement({ id: "d", index: "a1", version: 4 });
     writeDiff(roots, [], [el]);
@@ -78,7 +101,9 @@ describe("writeDiff: removal → tombstone (FR-B-006)", () => {
     expect(writes).toBeGreaterThan(0);
     const ymap = roots.elementsMap.get("d")!;
     expect(ymap.get("isDeleted")).toBe(true);
-    expect(ymap.get("version")).toBe(5);
+    // version is reconciliation metadata, never written to the doc — the old
+    // non-monotonic tombstone version write is gone (Fix #5 subsumed by Fix #1).
+    expect(ymap.has("version")).toBe(false);
     expect(roots.elementsMap.has("d")).toBe(true); // entry retained
 
     // removing an already-tombstoned element is a no-op

--- a/packages/yjs-binding/tests/diff-direct.test.ts
+++ b/packages/yjs-binding/tests/diff-direct.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+
+import type { BinaryFileData, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import { writeDiff, writeAppState } from "../src/diff";
+import {
+  deepEqual,
+  diffBoundElements,
+  elementToYMap,
+  writeChangedKeys,
+} from "../src/schema";
+
+import { Y, makeElement } from "./helpers";
+
+import type { ElementRecord } from "../src/schema";
+
+const makeRoots = () => {
+  const doc = new Y.Doc();
+  return {
+    ydoc: doc,
+    elementsMap: doc.getMap<Y.Map<unknown>>("elements"),
+    filesMap: doc.getMap<BinaryFileData>("files"),
+    appStateMap: doc.getMap<unknown>("appState"),
+  };
+};
+
+describe("writeDiff: new element index generation (findPrev/findNext)", () => {
+  it("generates an index between ordered neighbours for an indexless insert", () => {
+    const roots = makeRoots();
+    // two anchored elements
+    writeDiff(
+      roots,
+      [],
+      [
+        makeElement({ id: "a", index: "a1" }),
+        makeElement({ id: "c", index: "a3" }),
+      ],
+    );
+
+    // insert "b" with NO index between a and c (ordered array position)
+    const next: ElementRecord[] = [
+      makeElement({ id: "a", index: "a1" }),
+      makeElement({ id: "b", index: null }),
+      makeElement({ id: "c", index: "a3" }),
+    ];
+    writeDiff(roots, [], next);
+
+    const bIndex = roots.elementsMap.get("b")!.get("index") as string;
+    expect(bIndex > "a1").toBe(true);
+    expect(bIndex < "a3").toBe(true);
+  });
+
+  it("generates indices for a fully-indexless batch", () => {
+    const roots = makeRoots();
+    writeDiff(
+      roots,
+      [],
+      [
+        makeElement({ id: "x", index: null }),
+        makeElement({ id: "y", index: null }),
+      ],
+    );
+    const xi = roots.elementsMap.get("x")!.get("index") as string;
+    const yi = roots.elementsMap.get("y")!.get("index") as string;
+    expect(typeof xi).toBe("string");
+    expect(typeof yi).toBe("string");
+    expect(xi).not.toBe(yi);
+  });
+});
+
+describe("writeDiff: removal → tombstone (FR-B-006)", () => {
+  it("sets isDeleted=true and bumps version, never deletes the map entry", () => {
+    const roots = makeRoots();
+    const el = makeElement({ id: "d", index: "a1", version: 4 });
+    writeDiff(roots, [], [el]);
+
+    const writes = writeDiff(roots, [el], []); // removed from next
+    expect(writes).toBeGreaterThan(0);
+    const ymap = roots.elementsMap.get("d")!;
+    expect(ymap.get("isDeleted")).toBe(true);
+    expect(ymap.get("version")).toBe(5);
+    expect(roots.elementsMap.has("d")).toBe(true); // entry retained
+
+    // removing an already-tombstoned element is a no-op
+    const again = writeDiff(roots, [{ ...el, isDeleted: true }], []);
+    expect(again).toBe(0);
+  });
+});
+
+describe("writeDiff: files + appState branches", () => {
+  it("writes file and appState deltas", () => {
+    const roots = makeRoots();
+    const files: BinaryFiles = {
+      f: { id: "f", mimeType: "image/png", dataURL: "X", created: 1 } as never,
+    };
+    const writes = writeDiff(
+      roots,
+      [],
+      [makeElement({ id: "e", index: "a1" })],
+      { viewBackgroundColor: "#123456", name: "Board" } as never,
+      files,
+    );
+    expect(writes).toBeGreaterThan(0);
+    expect(roots.filesMap.has("f")).toBe(true);
+    expect(roots.appStateMap.get("viewBackgroundColor")).toBe("#123456");
+    expect(roots.appStateMap.get("name")).toBe("Board");
+  });
+
+  it("writeAppState skips undefined keys and no-op equal values", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<unknown>("appState");
+    doc.transact(() => {
+      expect(writeAppState(map, { viewBackgroundColor: "#fff" })).toBe(1);
+    });
+    doc.transact(() => {
+      expect(writeAppState(map, { viewBackgroundColor: "#fff" })).toBe(0);
+    });
+    doc.transact(() => {
+      expect(writeAppState(map, {})).toBe(0);
+    });
+  });
+});
+
+describe("schema: writeChangedKeys boundElements + diffBoundElements no-nested branch", () => {
+  it("writeChangedKeys diffs boundElements via the nested map", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    const el = makeElement({
+      id: "n",
+      boundElements: [{ id: "a1", type: "arrow" }],
+    });
+    doc.transact(() => map.set("n", elementToYMap(el)));
+
+    let writes = 0;
+    doc.transact(() => {
+      writes = writeChangedKeys(map.get("n")!, {
+        ...el,
+        boundElements: [
+          { id: "a1", type: "arrow" },
+          { id: "t1", type: "text" },
+        ],
+      });
+    });
+    expect(writes).toBe(1); // one add
+  });
+
+  it("diffBoundElements installs a nested map when the value is missing/non-map", () => {
+    const doc = new Y.Doc();
+    const parent = doc.getMap<unknown>("p");
+    let mutations = 0;
+    doc.transact(() => {
+      mutations = diffBoundElements(parent, [{ id: "x", type: "arrow" }]);
+    });
+    expect(mutations).toBe(1);
+    expect((parent.get("boundElements") as Y.Map<string>).get("x")).toBe(
+      "arrow",
+    );
+  });
+});
+
+describe("writeDiff: hasDiffWork boundElements branches", () => {
+  it("detects a same-size type change and a size change; ignores no-op", () => {
+    const roots = makeRoots();
+    const el = makeElement({
+      id: "n",
+      index: "a1",
+      boundElements: [{ id: "b1", type: "arrow" }],
+    });
+    writeDiff(roots, [], [el]);
+
+    // same id, type changes arrow→text (same size) → write
+    const typeChanged: ElementRecord = {
+      ...el,
+      version: 2,
+      boundElements: [{ id: "b1", type: "text" }],
+    };
+    expect(writeDiff(roots, [el], [typeChanged])).toBeGreaterThan(0);
+
+    // size change (add one) → write
+    const sizeChanged: ElementRecord = {
+      ...typeChanged,
+      version: 3,
+      boundElements: [
+        { id: "b1", type: "text" },
+        { id: "b2", type: "arrow" },
+      ],
+    };
+    expect(writeDiff(roots, [typeChanged], [sizeChanged])).toBeGreaterThan(0);
+
+    // identical boundElements + same version + no other change → no write
+    expect(writeDiff(roots, [sizeChanged], [sizeChanged])).toBe(0);
+  });
+
+  it("a file removal-only change triggers a write", () => {
+    const roots = makeRoots();
+    const files: BinaryFiles = {
+      f: { id: "f", mimeType: "image/png", dataURL: "X", created: 1 } as never,
+    };
+    writeDiff(
+      roots,
+      [],
+      [makeElement({ id: "e", index: "a1" })],
+      undefined,
+      files,
+    );
+    // now drop the file
+    const writes = writeDiff(
+      roots,
+      [makeElement({ id: "e", index: "a1" })],
+      [makeElement({ id: "e", index: "a1" })],
+      undefined,
+      {} as BinaryFiles,
+    );
+    expect(writes).toBeGreaterThan(0);
+    expect(roots.filesMap.has("f")).toBe(false);
+  });
+});
+
+describe("schema: deepEqual structural branches", () => {
+  it("covers array-vs-object, length mismatch, missing key, null/undefined", () => {
+    expect(deepEqual([1, 2], { 0: 1, 1: 2 })).toBe(false); // array vs object
+    expect(deepEqual([1, 2, 3], [1, 2])).toBe(false); // length
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, c: 2 })).toBe(false); // missing key
+    expect(deepEqual(1, "1")).toBe(false); // primitive mismatch
+    expect(deepEqual(null, 0)).toBe(false);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+  });
+});
+
+describe("schema: elementToYMap omits undefined keys", () => {
+  it("does not store keys whose value is undefined", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("e");
+    const el = makeElement({ id: "u" });
+    el.customData = undefined;
+    doc.transact(() => map.set("u", elementToYMap(el)));
+    expect(map.get("u")!.has("customData")).toBe(false);
+  });
+});

--- a/packages/yjs-binding/tests/echo.test.ts
+++ b/packages/yjs-binding/tests/echo.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import { BINDING_ORIGIN } from "../src/origin";
+
+import {
+  StubExcalidrawAPI,
+  WhiteboardBinding,
+  Y,
+  makeElement,
+} from "./helpers";
+
+/**
+ * Echo-prevention + minimal-write tests (US2 / SC-B-003, T010/T019). One binding
+ * + one recording stub; no second doc needed.
+ */
+
+describe("echo: minimal per-property writes (T010)", () => {
+  it("a single-property change emits exactly one transaction writing one key", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    const seed = makeElement({ id: "e1", strokeColor: "#000000", index: "a1" });
+    api.emitChange([seed]);
+
+    // Count transactions caused only by the next strokeColor change, and collect
+    // the distinct element keys mutated by the binding.
+    let txCount = 0;
+    const changedKeys = new Set<string>();
+    doc.on("afterTransaction", (tx: Y.Transaction) => {
+      if (tx.origin === BINDING_ORIGIN) {
+        txCount++;
+        for (const events of tx.changedParentTypes.values()) {
+          for (const event of events) {
+            for (const key of event.keys.keys()) {
+              changedKeys.add(key);
+            }
+          }
+        }
+      }
+    });
+
+    api.emitChange([{ ...api.elements[0], strokeColor: "#ff0000" }]);
+
+    expect(txCount).toBe(1);
+    // Only strokeColor is a meaningful change; version/versionNonce/updated are
+    // render metadata the editor bumps on any edit.
+    const meaningful = [...changedKeys].filter(
+      (k) => k !== "version" && k !== "versionNonce" && k !== "updated",
+    );
+    expect(meaningful).toEqual(["strokeColor"]);
+
+    binding.destroy();
+  });
+
+  it("a no-op onChange emits no transaction", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    api.emitChange([makeElement({ id: "n1", index: "a1" })]);
+
+    let txCount = 0;
+    doc.on("afterTransaction", (tx: Y.Transaction) => {
+      if (tx.origin === BINDING_ORIGIN) {
+        txCount++;
+      }
+    });
+
+    // Re-emit the identical element set (same version) → change gate skips it.
+    api.emitChange([{ ...api.elements[0] }]);
+    expect(txCount).toBe(0);
+
+    binding.destroy();
+  });
+});
+
+describe("echo: origin guard (T019 / SC-B-003)", () => {
+  it("a local edit → write → own-observe cycle triggers zero re-entrant updateScene", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    api.emitChange([makeElement({ id: "g1", index: "a1" })]);
+    const baseline = api.updateSceneCalls.length;
+
+    // A burst of local edits — none should cause the binding to re-apply its own
+    // writes back onto the scene (no echo).
+    for (let i = 0; i < 5; i++) {
+      api.emitChange([{ ...api.elements[0], x: i * 10 }]);
+    }
+
+    // No updateScene was triggered by our own observe handler (echo guard).
+    expect(api.updateSceneCalls.length).toBe(baseline);
+
+    binding.destroy();
+  });
+
+  it("preserves local selection/zoom/scroll when a remote update is applied", () => {
+    const doc = new Y.Doc();
+    const remote = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    // Local user has a selection + custom viewport.
+    api.appState.selectedElementIds = { local: true };
+    api.appState.zoom = { value: 2 };
+    api.appState.scrollX = 99;
+
+    // A remote element arrives via a second doc's update.
+    const remoteMap = remote.getMap<Y.Map<unknown>>("elements");
+    const ymap = new Y.Map<unknown>();
+    remote.transact(() => {
+      remoteMap.set("r1", ymap);
+      for (const [k, v] of Object.entries(
+        makeElement({ id: "r1", index: "a1" }),
+      )) {
+        if (k !== "boundElements") {
+          ymap.set(k, v as unknown);
+        }
+      }
+    });
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote)); // origin !== BINDING_ORIGIN
+
+    // updateScene was called for the remote element, but appState passed to it
+    // contains only the synced allow-list — never selection/zoom/scroll — so the
+    // host's local appState is preserved.
+    const lastCall = api.updateSceneCalls[api.updateSceneCalls.length - 1];
+    expect(lastCall.appState).toBeDefined();
+    expect(lastCall.appState).not.toHaveProperty("selectedElementIds");
+    expect(lastCall.appState).not.toHaveProperty("zoom");
+    expect(lastCall.appState).not.toHaveProperty("scrollX");
+    expect(lastCall.captureUpdate).toBe("NEVER");
+    expect(api.elements.find((e) => e.id === "r1")).toBeDefined();
+    // local selection still intact on the stub's appState
+    expect(api.appState.selectedElementIds).toEqual({ local: true });
+
+    binding.destroy();
+  });
+});

--- a/packages/yjs-binding/tests/echo.test.ts
+++ b/packages/yjs-binding/tests/echo.test.ts
@@ -96,6 +96,87 @@ describe("echo: origin guard (T019 / SC-B-003)", () => {
     binding.destroy();
   });
 
+  it("a remote apply with a RE-ENTRANT updateScene produces zero BINDING_ORIGIN writes and no runaway recursion (Fix #1)", () => {
+    const doc = new Y.Doc();
+    const remote = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    // Real Excalidraw re-fires onChange synchronously from inside updateScene.
+    api.reentrantUpdateScene = true;
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    // Count BINDING_ORIGIN transactions caused by the remote apply (the echo).
+    let bindingTx = 0;
+    doc.on("afterTransaction", (tx: Y.Transaction) => {
+      if (tx.origin === BINDING_ORIGIN) {
+        bindingTx++;
+      }
+    });
+    // Guard against unbounded re-entrant updateScene recursion (the stack-overflow
+    // symptom): cap updateScene calls and fail loudly if the loop runs away.
+    const updateSceneBefore = api.updateSceneCalls.length;
+
+    // A single remote element arrives via a second doc (origin !== BINDING_ORIGIN).
+    const remoteMap = remote.getMap<Y.Map<unknown>>("elements");
+    const ymap = new Y.Map<unknown>();
+    remote.transact(() => {
+      remoteMap.set("r1", ymap);
+      for (const [k, v] of Object.entries(
+        makeElement({ id: "r1", index: "a1", strokeColor: "#abcdef" }),
+      )) {
+        if (k !== "boundElements") {
+          ymap.set(k, v as unknown);
+        }
+      }
+    });
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote));
+
+    // The remote element landed in the scene…
+    expect(api.elements.find((e) => e.id === "r1")).toBeDefined();
+    // …with NO write echoed back into the doc under our origin…
+    expect(bindingTx).toBe(0);
+    // …and the re-entrant onChange did not spiral (exactly one apply → one
+    // updateScene; the synchronous onChange it provoked was swallowed by the
+    // re-entrancy guard, so no second apply ran).
+    expect(api.updateSceneCalls.length - updateSceneBefore).toBe(1);
+
+    binding.destroy();
+  });
+
+  it("a burst of remote applies (re-entrant updateScene) never echoes (Fix #1)", () => {
+    const doc = new Y.Doc();
+    const remote = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    api.reentrantUpdateScene = true;
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    const remoteApi = new StubExcalidrawAPI();
+    const remoteBinding = new WhiteboardBinding(
+      remote,
+      remoteApi.asBindingAPI(),
+    );
+
+    let bindingTx = 0;
+    doc.on("afterTransaction", (tx: Y.Transaction) => {
+      if (tx.origin === BINDING_ORIGIN) {
+        bindingTx++;
+      }
+    });
+
+    // Remote peer makes 5 successive edits; each propagates to the local doc.
+    remoteApi.emitChange([makeElement({ id: "m", x: 0, index: "a1" })]);
+    for (let i = 1; i <= 5; i++) {
+      remoteApi.emitChange([{ ...remoteApi.elements[0], x: i * 10 }]);
+      Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote));
+    }
+
+    // Every remote x is reflected locally and nothing was echoed back.
+    expect(api.elements.find((e) => e.id === "m")!.x).toBe(50);
+    expect(bindingTx).toBe(0);
+
+    binding.destroy();
+    remoteBinding.destroy();
+  });
+
   it("preserves local selection/zoom/scroll when a remote update is applied", () => {
     const doc = new Y.Doc();
     const remote = new Y.Doc();

--- a/packages/yjs-binding/tests/helpers.ts
+++ b/packages/yjs-binding/tests/helpers.ts
@@ -14,6 +14,13 @@ import type { ElementRecord } from "../src/schema";
 export class StubExcalidrawAPI {
   elements: ElementRecord[] = [];
   files: Record<string, unknown> = {};
+  /**
+   * When true, `updateScene` re-fires `onChange` synchronously — exactly like
+   * real Excalidraw (App.componentDidUpdate → onChangeEmitter). Off by default
+   * so the legacy tests (whose stub `updateScene` is a silent no-op) keep
+   * working; the echo test flips it on to exercise the re-entrancy guard.
+   */
+  reentrantUpdateScene = false;
   appState: Record<string, unknown> = {
     viewBackgroundColor: "#ffffff",
     name: "Untitled",
@@ -62,6 +69,16 @@ export class StubExcalidrawAPI {
     }
     if (sceneData.collaborators) {
       this.collaborators = sceneData.collaborators;
+    }
+    // Real Excalidraw emits onChange synchronously after the scene updates
+    // (componentDidUpdate → onChangeEmitter). When enabled, replay that here so
+    // the binding's re-entrancy guard is exercised. We re-fire with the SCENE's
+    // current elements verbatim (no version re-bump — the editor does not invent
+    // a new version just because updateScene ran).
+    if (this.reentrantUpdateScene && sceneData.elements) {
+      for (const handler of this.changeHandlers) {
+        handler(this.elements, this.appState, this.files ?? {});
+      }
     }
   };
 

--- a/packages/yjs-binding/tests/helpers.ts
+++ b/packages/yjs-binding/tests/helpers.ts
@@ -1,0 +1,212 @@
+import * as Y from "yjs";
+
+import { WhiteboardBinding } from "../src/index";
+
+import type { AwarenessRouter } from "../src/awareness";
+import type { BindingExcalidrawAPI } from "../src/index";
+import type { ElementRecord } from "../src/schema";
+
+/**
+ * A recording stub of the Excalidraw imperative API surface the binding drives.
+ * Holds an in-memory element/file/appState store, fires `onChange` subscribers,
+ * and counts `updateScene` calls so tests can assert echo behavior.
+ */
+export class StubExcalidrawAPI {
+  elements: ElementRecord[] = [];
+  files: Record<string, unknown> = {};
+  appState: Record<string, unknown> = {
+    viewBackgroundColor: "#ffffff",
+    name: "Untitled",
+    selectedElementIds: {},
+    zoom: { value: 1 },
+    scrollX: 0,
+    scrollY: 0,
+  };
+  collaborators = new Map<string, unknown>();
+
+  updateSceneCalls: Array<{
+    elements?: ElementRecord[];
+    appState?: Record<string, unknown>;
+    collaborators?: Map<string, unknown>;
+    captureUpdate?: string;
+  }> = [];
+
+  private changeHandlers = new Set<
+    (
+      elements: readonly ElementRecord[],
+      appState: Record<string, unknown>,
+      files: Record<string, unknown>,
+    ) => void
+  >();
+
+  dispatchedEmoji: unknown[] = [];
+  dispatchedCountdown: unknown[] = [];
+
+  updateScene = (sceneData: {
+    elements?: ElementRecord[];
+    appState?: Record<string, unknown> | null;
+    collaborators?: Map<string, unknown>;
+    captureUpdate?: string;
+  }): void => {
+    this.updateSceneCalls.push({
+      elements: sceneData.elements,
+      appState: sceneData.appState ?? undefined,
+      collaborators: sceneData.collaborators,
+      captureUpdate: sceneData.captureUpdate,
+    });
+    if (sceneData.elements) {
+      this.elements = sceneData.elements.map((el) => ({ ...el }));
+    }
+    if (sceneData.appState) {
+      this.appState = { ...this.appState, ...sceneData.appState };
+    }
+    if (sceneData.collaborators) {
+      this.collaborators = sceneData.collaborators;
+    }
+  };
+
+  getSceneElementsIncludingDeleted = (): ElementRecord[] => this.elements;
+
+  getFiles = (): Record<string, unknown> => this.files;
+
+  addFiles = (data: Array<{ id: string }>): void => {
+    for (const file of data) {
+      this.files[file.id] = file;
+    }
+  };
+
+  getAppState = (): Record<string, unknown> => this.appState;
+
+  onChange = (
+    cb: (
+      elements: readonly ElementRecord[],
+      appState: Record<string, unknown>,
+      files: Record<string, unknown>,
+    ) => void,
+  ): (() => void) => {
+    this.changeHandlers.add(cb);
+    return () => this.changeHandlers.delete(cb);
+  };
+
+  dispatchIncomingEmojiReaction = (payload: unknown): void => {
+    this.dispatchedEmoji.push(payload);
+  };
+
+  dispatchIncomingCountdownTimer = (payload: unknown): void => {
+    this.dispatchedCountdown.push(payload);
+  };
+
+  /**
+   * Simulate the editor emitting an onChange after a local edit. Mirrors the
+   * real editor's `mutateElement`: any element whose content changed relative to
+   * the current scene gets its `version`/`versionNonce` bumped, so the binding's
+   * `(id, version)` change gate (`areElementsSame`) sees the edit.
+   */
+  emitChange(
+    elements: ElementRecord[],
+    appState?: Record<string, unknown>,
+    files?: Record<string, unknown>,
+  ): void {
+    const prevById = new Map(this.elements.map((el) => [el.id as string, el]));
+    this.elements = elements.map((el) => {
+      const prev = prevById.get(el.id as string);
+      const next = { ...el };
+      if (!prev) {
+        return next;
+      }
+      const {
+        version: _pv,
+        versionNonce: _pn,
+        updated: _pu,
+        ...prevRest
+      } = prev;
+      const {
+        version: _nv,
+        versionNonce: _nn,
+        updated: _nu,
+        ...nextRest
+      } = next;
+      if (JSON.stringify(prevRest) !== JSON.stringify(nextRest)) {
+        next.version = ((prev.version as number) ?? 0) + 1;
+        next.versionNonce = Math.floor(Math.random() * 2 ** 31);
+        next.updated = Date.now();
+      }
+      return next;
+    });
+    if (appState) {
+      this.appState = { ...this.appState, ...appState };
+    }
+    if (files) {
+      this.files = { ...this.files, ...files };
+    }
+    for (const handler of this.changeHandlers) {
+      handler(this.elements, this.appState, this.files ?? {});
+    }
+  }
+
+  asBindingAPI(): BindingExcalidrawAPI {
+    return this as unknown as BindingExcalidrawAPI;
+  }
+
+  /** The minimal `api` shape an `AwarenessRouter` expects. */
+  routerApi(): AwarenessRouterApi {
+    return {
+      updateScene: this.updateScene,
+      dispatchIncomingEmojiReaction: this.dispatchIncomingEmojiReaction,
+      dispatchIncomingCountdownTimer: this.dispatchIncomingCountdownTimer,
+    } as unknown as AwarenessRouterApi;
+  }
+}
+
+type AwarenessRouterApi = ConstructorParameters<
+  typeof AwarenessRouter
+>[0]["api"];
+
+let seq = 0;
+
+/** Build a minimal valid rectangle element with sensible defaults. */
+export const makeElement = (
+  overrides: Partial<ElementRecord> & { id: string },
+): ElementRecord => ({
+  type: "rectangle",
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 100,
+  angle: 0,
+  strokeColor: "#1e1e1e",
+  backgroundColor: "transparent",
+  fillStyle: "solid",
+  strokeWidth: 2,
+  strokeStyle: "solid",
+  roughness: 1,
+  opacity: 100,
+  seed: ++seq,
+  version: 1,
+  versionNonce: ++seq,
+  updated: 1,
+  index: null,
+  isDeleted: false,
+  groupIds: [],
+  frameId: null,
+  boundElements: null,
+  roundness: null,
+  link: null,
+  locked: false,
+  ...overrides,
+});
+
+/**
+ * Exchange Yjs updates between two docs both ways until they converge (one round
+ * is enough for these tests, but we do two to settle index-repair writes).
+ */
+export const sync = (a: Y.Doc, b: Y.Doc): void => {
+  for (let round = 0; round < 3; round++) {
+    const aState = Y.encodeStateAsUpdate(a);
+    const bState = Y.encodeStateAsUpdate(b);
+    Y.applyUpdate(b, aState);
+    Y.applyUpdate(a, bState);
+  }
+};
+
+export { WhiteboardBinding, Y };

--- a/packages/yjs-binding/tests/merge.test.ts
+++ b/packages/yjs-binding/tests/merge.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  StubExcalidrawAPI,
+  WhiteboardBinding,
+  Y,
+  makeElement,
+  sync,
+} from "./helpers";
+
+import type { ElementRecord } from "../src/schema";
+
+/**
+ * Two in-process `Y.Doc`s, each with its own binding + stub API. This is the
+ * no-backend convergence harness the spec mandates (SC-B-001/002).
+ */
+const setup = () => {
+  const docA = new Y.Doc();
+  const docB = new Y.Doc();
+  const apiA = new StubExcalidrawAPI();
+  const apiB = new StubExcalidrawAPI();
+  const bindingA = new WhiteboardBinding(docA, apiA.asBindingAPI());
+  const bindingB = new WhiteboardBinding(docB, apiB.asBindingAPI());
+  return { docA, docB, apiA, apiB, bindingA, bindingB };
+};
+
+const find = (api: StubExcalidrawAPI, id: string): ElementRecord | undefined =>
+  api.elements.find((e) => e.id === id);
+
+describe("merge: US1 per-property convergence (T026 / SC-B-001)", () => {
+  it("concurrent edits to DIFFERENT properties both survive", () => {
+    const { docA, docB, apiA, apiB, bindingA, bindingB } = setup();
+
+    // Seed one shared element and sync it to both docs.
+    const seed = makeElement({
+      id: "shape-1",
+      x: 0,
+      y: 0,
+      strokeColor: "#000000",
+      index: "a1",
+    });
+    apiA.emitChange([seed]);
+    sync(docA, docB);
+
+    // Partition: A drags (x/y), B recolors (strokeColor) — no exchange yet.
+    apiA.emitChange([{ ...find(apiA, "shape-1")!, x: 200, y: 150 }]);
+    apiB.emitChange([{ ...find(apiB, "shape-1")!, strokeColor: "#ff0000" }]);
+
+    // Exchange updates both ways.
+    sync(docA, docB);
+
+    // Both docs carry A's position AND B's color.
+    for (const api of [apiA, apiB]) {
+      const el = find(api, "shape-1")!;
+      expect(el.x).toBe(200);
+      expect(el.y).toBe(150);
+      expect(el.strokeColor).toBe("#ff0000");
+    }
+
+    bindingA.destroy();
+    bindingB.destroy();
+  });
+
+  it("boundElements set-merge: concurrent binds to one node both survive", () => {
+    const { docA, docB, apiA, apiB, bindingA, bindingB } = setup();
+
+    const node = makeElement({
+      id: "node-1",
+      index: "a1",
+      boundElements: null,
+    });
+    apiA.emitChange([node]);
+    sync(docA, docB);
+
+    // A binds arrow-1, B binds arrow-2 to the SAME node, concurrently.
+    apiA.emitChange([
+      {
+        ...find(apiA, "node-1")!,
+        boundElements: [{ id: "arrow-1", type: "arrow" }],
+      },
+    ]);
+    apiB.emitChange([
+      {
+        ...find(apiB, "node-1")!,
+        boundElements: [{ id: "arrow-2", type: "arrow" }],
+      },
+    ]);
+
+    sync(docA, docB);
+
+    for (const api of [apiA, apiB]) {
+      const el = find(api, "node-1")!;
+      const ids = (el.boundElements as Array<{ id: string }>)
+        .map((b) => b.id)
+        .sort();
+      expect(ids).toEqual(["arrow-1", "arrow-2"]);
+    }
+
+    bindingA.destroy();
+    bindingB.destroy();
+  });
+});
+
+describe("merge: same-property tiebreak (T027 / US1-AC2)", () => {
+  it("concurrent same-property edits converge to one deterministic value", () => {
+    const { docA, docB, apiA, apiB, bindingA, bindingB } = setup();
+
+    const seed = makeElement({ id: "s1", strokeColor: "#000000", index: "a1" });
+    apiA.emitChange([seed]);
+    sync(docA, docB);
+
+    apiA.emitChange([{ ...find(apiA, "s1")!, strokeColor: "#aaaaaa" }]);
+    apiB.emitChange([{ ...find(apiB, "s1")!, strokeColor: "#bbbbbb" }]);
+
+    expect(() => sync(docA, docB)).not.toThrow();
+
+    const colorA = find(apiA, "s1")!.strokeColor;
+    const colorB = find(apiB, "s1")!.strokeColor;
+    expect(colorA).toBe(colorB); // converged, no divergence
+    expect(["#aaaaaa", "#bbbbbb"]).toContain(colorA);
+
+    bindingA.destroy();
+    bindingB.destroy();
+  });
+});
+
+describe("merge: delete-vs-edit (T028 / US1-AC3)", () => {
+  it("tombstone wins render; concurrent edit retained on the tombstone", () => {
+    const { docA, docB, apiA, apiB, bindingA, bindingB } = setup();
+
+    const seed = makeElement({
+      id: "d1",
+      x: 0,
+      strokeColor: "#000000",
+      index: "a1",
+    });
+    apiA.emitChange([seed]);
+    sync(docA, docB);
+
+    // A deletes (removes from array → tombstone); B edits a property concurrently.
+    apiA.emitChange([]); // d1 removed from A's array
+    apiB.emitChange([{ ...find(apiB, "d1")!, strokeColor: "#00ff00" }]);
+
+    sync(docA, docB);
+
+    // Both docs converge: element is a tombstone (isDeleted=true) → absent from
+    // the rendered (non-deleted) set, but the edit is retained on the tombstone.
+    for (const { docElements } of [
+      { docElements: includingDeleted(docA) },
+      { docElements: includingDeleted(docB) },
+    ]) {
+      const tomb = docElements.find((e) => e.id === "d1")!;
+      expect(tomb.isDeleted).toBe(true);
+      expect(tomb.strokeColor).toBe("#00ff00"); // concurrent edit retained
+    }
+
+    // Rendered scene (updateScene receives the full set incl. tombstones; the
+    // host filters non-deleted for render) — assert the tombstone is flagged.
+    for (const api of [apiA, apiB]) {
+      const rendered = api.elements.filter((e) => e.isDeleted !== true);
+      expect(rendered.find((e) => e.id === "d1")).toBeUndefined();
+    }
+
+    bindingA.destroy();
+    bindingB.destroy();
+  });
+});
+
+/** Read the doc's element maps directly (including tombstones). */
+const includingDeleted = (doc: Y.Doc): ElementRecord[] => {
+  const map = doc.getMap<Y.Map<unknown>>("elements");
+  const out: ElementRecord[] = [];
+  for (const [id, ymap] of map.entries()) {
+    const el: ElementRecord = { id };
+    for (const [k, v] of ymap.entries()) {
+      if (k !== "boundElements") {
+        el[k] = v;
+      }
+    }
+    out.push(el);
+  }
+  return out;
+};

--- a/packages/yjs-binding/tests/merge.test.ts
+++ b/packages/yjs-binding/tests/merge.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { BINDING_ORIGIN } from "../src/origin";
+import { extraBoundTextIds } from "../src/schema";
+
 import {
   StubExcalidrawAPI,
   WhiteboardBinding,
@@ -163,6 +166,66 @@ describe("merge: delete-vs-edit (T028 / US1-AC3)", () => {
 
     bindingA.destroy();
     bindingB.destroy();
+  });
+});
+
+describe("merge: boundElements 'at most one text' reconciled into the doc (Fix #6)", () => {
+  it("drops the extra text binding from the doc so doc and scene agree (no flap)", () => {
+    const doc = new Y.Doc();
+    const remote = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    // Seed a node with one bound text via the binding.
+    api.emitChange([
+      makeElement({
+        id: "node",
+        index: "a1",
+        boundElements: [{ id: "text-b", type: "text" }],
+      }),
+    ]);
+    sync(doc, remote);
+
+    // Concurrency on a remote replica adds a SECOND text binding directly into
+    // the nested map (the invariant violation the binding must reconcile).
+    const remoteMap = remote.getMap<Y.Map<unknown>>("elements");
+    remote.transact(() => {
+      const nested = remoteMap.get("node")!.get("boundElements") as Y.Map<
+        "arrow" | "text"
+      >;
+      nested.set("text-a", "text"); // lower id than text-b
+    });
+    // Two text bindings now exist on the remote nested map.
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote)); // → applyToScene on local
+
+    // The binding reconciled the invariant INTO the local doc: only the lowest id
+    // (text-a) survives; the extra (text-b) was deleted under BINDING_ORIGIN.
+    const localNested = doc
+      .getMap<Y.Map<unknown>>("elements")
+      .get("node")!
+      .get("boundElements") as Y.Map<"arrow" | "text">;
+    expect(extraBoundTextIds(localNested)).toEqual([]);
+    const texts = [...localNested.entries()].filter(([, t]) => t === "text");
+    expect(texts.map(([id]) => id)).toEqual(["text-a"]);
+
+    // The materialized scene element agrees with the doc — exactly one bound text.
+    const sceneNode = api.elements.find((e) => e.id === "node")!;
+    const sceneTexts = (
+      sceneNode.boundElements as Array<{ id: string; type: string }>
+    ).filter((b) => b.type === "text");
+    expect(sceneTexts.map((b) => b.id)).toEqual(["text-a"]);
+
+    // And no flap: re-emitting the reconciled scene produces zero further writes.
+    let bindingTx = 0;
+    doc.on("afterTransaction", (tx: Y.Transaction) => {
+      if (tx.origin === BINDING_ORIGIN) {
+        bindingTx++;
+      }
+    });
+    api.emitChange([{ ...sceneNode }]);
+    expect(bindingTx).toBe(0);
+
+    binding.destroy();
   });
 });
 

--- a/packages/yjs-binding/tests/order.test.ts
+++ b/packages/yjs-binding/tests/order.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  keyBetween,
+  keysBetween,
+  orderByIndex,
+  repairIndices,
+} from "../src/order";
+
+import type { ElementRecord } from "../src/schema";
+
+const el = (id: string, index: string | null): ElementRecord => ({ id, index });
+
+describe("order: orderByIndex (T005)", () => {
+  it("orders by fractional index, ties broken by id", () => {
+    const out = orderByIndex([el("c", "a2"), el("a", "a1"), el("b", "a1")]);
+    expect(out.map((e) => e.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [el("b", "a2"), el("a", "a1")];
+    const copy = [...input];
+    orderByIndex(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+describe("order: key generation reuses fractional-indexing", () => {
+  it("keyBetween produces a key strictly between neighbours", () => {
+    const k = keyBetween("a1", "a3");
+    expect(k > "a1").toBe(true);
+    expect(k < "a3").toBe(true);
+  });
+
+  it("keysBetween produces n sorted distinct keys", () => {
+    const keys = keysBetween(null, null, 3);
+    expect(keys).toHaveLength(3);
+    expect([...keys].sort()).toEqual(keys);
+    expect(new Set(keys).size).toBe(3);
+  });
+});
+
+describe("order: repairIndices collision repair (T013/T029)", () => {
+  it("repairs two elements that picked the same index (deterministic by id)", () => {
+    const a = [el("z", "a1"), el("a", "a1")];
+    const { ordered, repaired } = repairIndices(a);
+    // tie broken by id → a before z; the later one (z) gets a new strictly-greater index
+    expect(ordered.map((e) => e.id)).toEqual(["a", "z"]);
+    expect(ordered[0].index! < (ordered[1].index as string)).toBe(true);
+    expect(repaired.has("z")).toBe(true);
+  });
+
+  it("is idempotent — a second pass repairs nothing", () => {
+    const a = [el("z", "a1"), el("a", "a1"), el("m", "a1")];
+    const { ordered } = repairIndices(a);
+    const second = repairIndices(ordered);
+    expect(second.repaired.size).toBe(0);
+    expect(second.ordered.map((e) => e.id)).toEqual(ordered.map((e) => e.id));
+  });
+
+  it("two replicas with the same colliding set converge to identical order", () => {
+    const docA = [el("z", "a1"), el("a", "a1")];
+    const docB = [el("a", "a1"), el("z", "a1")]; // different array order
+    const ra = repairIndices(docA).ordered;
+    const rb = repairIndices(docB).ordered;
+    expect(ra.map((e) => `${e.id}:${e.index}`)).toEqual(
+      rb.map((e) => `${e.id}:${e.index}`),
+    );
+  });
+
+  it("seeds indices for elements that have none", () => {
+    const a = [el("a", null), el("b", null), el("c", null)];
+    const { ordered } = repairIndices(a);
+    expect(ordered.every((e) => typeof e.index === "string")).toBe(true);
+    const indices = ordered.map((e) => e.index as string);
+    expect([...indices].sort()).toEqual(indices);
+  });
+});

--- a/packages/yjs-binding/tests/roundtrip.test.ts
+++ b/packages/yjs-binding/tests/roundtrip.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import { exportSceneJSON, populateYDoc } from "../src/migrate";
+import { orderByIndex } from "../src/order";
+
+import { Y, makeElement } from "./helpers";
+
+import type { SceneJSON } from "../src/migrate";
+import type { ElementRecord } from "../src/schema";
+
+/**
+ * Round-trip losslessness (US5 / SC-B-005, T025). A representative legacy scene
+ * (text + arrow w/ points + image fileId + grouped + soft-deleted + customData +
+ * bound text/arrows) must survive `populateYDoc → exportSceneJSON` deep-equal
+ * modulo the data-model §6 normalization rules.
+ */
+
+const representativeScene = (): SceneJSON => {
+  const node = makeElement({
+    id: "rect-1",
+    index: "a1",
+    groupIds: ["group-1"],
+    boundElements: [
+      { id: "arrow-1", type: "arrow" },
+      { id: "text-1", type: "text" },
+    ],
+    customData: { alkemio: { foo: "bar", n: [1, 2, 3] } },
+  });
+  const boundText = makeElement({
+    id: "text-1",
+    type: "text",
+    index: "a2",
+    text: "label",
+    originalText: "label",
+    fontSize: 16,
+    fontFamily: 1,
+    textAlign: "center",
+    verticalAlign: "middle",
+    containerId: "rect-1",
+    lineHeight: 1.25,
+    autoResize: true,
+    groupIds: ["group-1"],
+  });
+  const arrow = makeElement({
+    id: "arrow-1",
+    type: "arrow",
+    index: "a3",
+    points: [
+      [0, 0],
+      [50, 50],
+      [100, 0],
+    ],
+    startBinding: { elementId: "rect-1", focus: 0.1, gap: 4 },
+    endBinding: null,
+    startArrowhead: null,
+    endArrowhead: "arrow",
+    elbowed: false,
+  });
+  const image = makeElement({
+    id: "img-1",
+    type: "image",
+    index: "a4",
+    fileId: "file-xyz",
+    status: "saved",
+    scale: [1, -1],
+    crop: null,
+  });
+  const freedraw = makeElement({
+    id: "draw-1",
+    type: "freedraw",
+    index: "a5",
+    points: [
+      [0, 0],
+      [1, 2],
+      [3, 1],
+    ],
+    pressures: [0.1, 0.4, 0.8],
+    simulatePressure: true,
+  });
+  const tombstone = makeElement({
+    id: "gone-1",
+    index: "a6",
+    isDeleted: true,
+  });
+
+  return {
+    elements: [node, boundText, arrow, image, freedraw, tombstone],
+    files: {
+      "file-xyz": {
+        id: "file-xyz",
+        mimeType: "image/png",
+        dataURL: "data:image/png;base64,AAAA",
+        created: 123,
+      } as never,
+    },
+    appState: { viewBackgroundColor: "#f5f5f5", name: "My Board" },
+  };
+};
+
+/** Normalize: drop version/versionNonce/updated (data-model §6 rule 1). */
+const normalize = (el: ElementRecord): ElementRecord => {
+  const { version, versionNonce, updated, ...rest } = el;
+  void version;
+  void versionNonce;
+  void updated;
+  return rest;
+};
+
+describe("roundtrip: lossless JSON ↔ Y.Doc (T025 / SC-B-005)", () => {
+  it("round-trips a representative scene deep-equal modulo §6 normalization", () => {
+    const scene = representativeScene();
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+
+    // Order by index, compare element-by-element (incl. tombstones).
+    const srcOrdered = orderByIndex(scene.elements).map(normalize);
+    const outOrdered = orderByIndex(out.elements).map(normalize);
+
+    expect(outOrdered).toEqual(srcOrdered);
+  });
+
+  it("preserves files verbatim (deep-equal — §6 rule 4)", () => {
+    const scene = representativeScene();
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+    expect(out.files).toEqual(scene.files);
+  });
+
+  it("preserves the appState allow-list", () => {
+    const scene = representativeScene();
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+    expect(out.appState).toEqual({
+      viewBackgroundColor: "#f5f5f5",
+      name: "My Board",
+    });
+  });
+
+  it("preserves bound text + arrows (boundElements/containerId/startBinding — US5-AC2)", () => {
+    const scene = representativeScene();
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+
+    const node = out.elements.find((e) => e.id === "rect-1")!;
+    expect(node.boundElements).toEqual([
+      { id: "arrow-1", type: "arrow" },
+      { id: "text-1", type: "text" },
+    ]);
+    const text = out.elements.find((e) => e.id === "text-1")!;
+    expect(text.containerId).toBe("rect-1");
+    const arrow = out.elements.find((e) => e.id === "arrow-1")!;
+    expect(arrow.startBinding).toEqual({
+      elementId: "rect-1",
+      focus: 0.1,
+      gap: 4,
+    });
+  });
+
+  it("carries tombstones through unchanged (§6 rule 5)", () => {
+    const scene = representativeScene();
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+    const tomb = out.elements.find((e) => e.id === "gone-1")!;
+    expect(tomb.isDeleted).toBe(true);
+  });
+
+  it("repairs missing indices on load, preserving source array order (§6 rule 3)", () => {
+    const scene: SceneJSON = {
+      elements: [
+        makeElement({ id: "first", index: null }),
+        makeElement({ id: "second", index: null }),
+        makeElement({ id: "third", index: null }),
+      ],
+    };
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["first", "second", "third"]);
+    expect(out.elements.every((e) => typeof e.index === "string")).toBe(true);
+  });
+});

--- a/packages/yjs-binding/tests/roundtrip.test.ts
+++ b/packages/yjs-binding/tests/roundtrip.test.ts
@@ -183,4 +183,52 @@ describe("roundtrip: lossless JSON ↔ Y.Doc (T025 / SC-B-005)", () => {
     expect(out.elements.map((e) => e.id)).toEqual(["first", "second", "third"]);
     expect(out.elements.every((e) => typeof e.index === "string")).toBe(true);
   });
+
+  it("seeds a PARTIALLY-missing index in source order, not at the back (Fix #4)", () => {
+    // The reproduction: X, Y(no idx), Z. Y must keep its middle position.
+    const scene: SceneJSON = {
+      elements: [
+        makeElement({ id: "X", index: "a1" }),
+        makeElement({ id: "Y", index: null }),
+        makeElement({ id: "Z", index: "a3" }),
+      ],
+    };
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["X", "Y", "Z"]);
+    expect(out.elements.every((e) => typeof e.index === "string")).toBe(true);
+    // strictly increasing indices
+    const idx = out.elements.map((e) => e.index as string);
+    expect([...idx].sort()).toEqual(idx);
+  });
+
+  it("seeds a leading no-index element at the front (Fix #4)", () => {
+    const scene: SceneJSON = {
+      elements: [
+        makeElement({ id: "lead", index: null }),
+        makeElement({ id: "A", index: "a1" }),
+        makeElement({ id: "B", index: "a2" }),
+      ],
+    };
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["lead", "A", "B"]);
+  });
+
+  it("seeds a run of consecutive no-index elements in source order (Fix #4)", () => {
+    const scene: SceneJSON = {
+      elements: [
+        makeElement({ id: "A", index: "a1" }),
+        makeElement({ id: "M1", index: null }),
+        makeElement({ id: "M2", index: null }),
+        makeElement({ id: "Z", index: "a5" }),
+      ],
+    };
+    const doc = new Y.Doc();
+    populateYDoc(scene, doc);
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["A", "M1", "M2", "Z"]);
+  });
 });

--- a/packages/yjs-binding/tests/schema.test.ts
+++ b/packages/yjs-binding/tests/schema.test.ts
@@ -1,0 +1,223 @@
+import * as Y from "yjs";
+import { describe, expect, it } from "vitest";
+
+import {
+  BOUND_ELEMENTS_KEY,
+  boundElementsToYMap,
+  deepEqual,
+  diffBoundElements,
+  elementToYMap,
+  writeChangedKeys,
+  yMapToBoundElements,
+  yMapToElement,
+} from "../src/schema";
+
+import { makeElement } from "./helpers";
+
+import type { ElementRecord } from "../src/schema";
+
+const roundtrip = (el: ElementRecord): ElementRecord => {
+  const doc = new Y.Doc();
+  const map = doc.getMap<Y.Map<unknown>>("elements");
+  doc.transact(() => map.set(el.id as string, elementToYMap(el)));
+  return yMapToElement(map.get(el.id as string)!);
+};
+
+describe("schema: element encode/decode (T003/T004)", () => {
+  it("round-trips a base rectangle losslessly (scalars ===)", () => {
+    const el = makeElement({ id: "r1", x: 5, y: 7, strokeColor: "#ff0000" });
+    const back = roundtrip(el);
+    expect(back).toEqual(el);
+    expect(back.x).toBe(5);
+    expect(back.strokeColor).toBe("#ff0000");
+  });
+
+  it("round-trips a text element subtype fields", () => {
+    const el = makeElement({
+      id: "t1",
+      type: "text",
+      text: "hello",
+      originalText: "hello",
+      fontSize: 20,
+      fontFamily: 1,
+      textAlign: "left",
+      verticalAlign: "top",
+      containerId: null,
+      lineHeight: 1.25,
+      autoResize: true,
+    });
+    expect(roundtrip(el)).toEqual(el);
+  });
+
+  it("round-trips JSON-leaf props by deep value equality (points/groupIds/customData)", () => {
+    const el = makeElement({
+      id: "l1",
+      type: "line",
+      points: [
+        [0, 0],
+        [10, 20],
+        [30, 5],
+      ],
+      pressures: [0.1, 0.5, 0.9],
+      groupIds: ["g1", "g2"],
+      roundness: { type: 2, value: 32 },
+      startBinding: { elementId: "x", focus: 0, gap: 1 },
+      endBinding: null,
+      customData: { alkemio: { nested: [1, 2, { a: true }] } },
+    });
+    const back = roundtrip(el);
+    expect(deepEqual(back.points, el.points)).toBe(true);
+    expect(deepEqual(back.groupIds, el.groupIds)).toBe(true);
+    expect(deepEqual(back.customData, el.customData)).toBe(true);
+    // JSON-leaf values are deep-cloned (no shared ref with the source)
+    expect(back.points).not.toBe(el.points);
+  });
+
+  it("round-trips an image element scale/crop/fileId", () => {
+    const el = makeElement({
+      id: "img1",
+      type: "image",
+      fileId: "file-abc",
+      status: "saved",
+      scale: [1, -1],
+      crop: {
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        naturalWidth: 20,
+        naturalHeight: 20,
+      },
+    });
+    expect(roundtrip(el)).toEqual(el);
+  });
+
+  it("omits undefined keys (customData absent) for round-trip symmetry", () => {
+    const el = makeElement({ id: "u1" });
+    delete el.customData;
+    const back = roundtrip(el);
+    expect("customData" in back).toBe(false);
+  });
+});
+
+describe("schema: boundElements nested Y.Map (§4.1)", () => {
+  it("encodes/decodes boundElements as an add/remove set", () => {
+    const el = makeElement({
+      id: "node1",
+      boundElements: [
+        { id: "arrow-1", type: "arrow" },
+        { id: "text-1", type: "text" },
+      ],
+    });
+    const back = roundtrip(el);
+    // order-insensitive, materialized deterministically
+    expect(back.boundElements).toEqual([
+      { id: "arrow-1", type: "arrow" },
+      { id: "text-1", type: "text" },
+    ]);
+  });
+
+  it("materializes an empty bound map back to null", () => {
+    const doc = new Y.Doc();
+    const parent = doc.getMap<unknown>("p");
+    const map = boundElementsToYMap(null);
+    doc.transact(() => parent.set(BOUND_ELEMENTS_KEY, map));
+    expect(yMapToBoundElements(map)).toBeNull();
+  });
+
+  it("resolves the 'at most one bound text' invariant by lowest id", () => {
+    const doc = new Y.Doc();
+    const parent = doc.getMap<unknown>("p");
+    const map = new Y.Map<"arrow" | "text">();
+    doc.transact(() => {
+      parent.set(BOUND_ELEMENTS_KEY, map);
+      map.set("text-b", "text");
+      map.set("text-a", "text");
+      map.set("arrow-1", "arrow");
+    });
+    const back = yMapToBoundElements(map)!;
+    const texts = back.filter((b) => b.type === "text");
+    expect(texts).toHaveLength(1);
+    expect(texts[0].id).toBe("text-a"); // lowest id kept
+    expect(back.some((b) => b.id === "arrow-1")).toBe(true);
+  });
+
+  it("diffBoundElements applies only the delta (add/remove)", () => {
+    const doc = new Y.Doc();
+    const parent = doc.getMap<unknown>("p");
+    doc.transact(() => {
+      parent.set(
+        BOUND_ELEMENTS_KEY,
+        boundElementsToYMap([{ id: "a1", type: "arrow" }]),
+      );
+    });
+    let mutations = 0;
+    doc.transact(() => {
+      mutations = diffBoundElements(parent, [
+        { id: "a1", type: "arrow" },
+        { id: "a2", type: "arrow" },
+      ]);
+    });
+    expect(mutations).toBe(1); // only a2 added
+    const nested = parent.get(BOUND_ELEMENTS_KEY) as Y.Map<string>;
+    expect([...nested.keys()].sort()).toEqual(["a1", "a2"]);
+  });
+});
+
+describe("schema: writeChangedKeys per-property diff (T007)", () => {
+  it("writes only the keys that actually changed", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    const el = makeElement({ id: "e1", x: 0, strokeColor: "#000000" });
+    doc.transact(() => map.set("e1", elementToYMap(el)));
+
+    const ymap = map.get("e1")!;
+    let writes = 0;
+    doc.transact(() => {
+      writes = writeChangedKeys(ymap, { ...el, strokeColor: "#ff0000" });
+    });
+    expect(writes).toBe(1);
+    expect(ymap.get("strokeColor")).toBe("#ff0000");
+    expect(ymap.get("x")).toBe(0);
+  });
+
+  it("returns 0 writes when nothing changed", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    const el = makeElement({ id: "e2" });
+    doc.transact(() => map.set("e2", elementToYMap(el)));
+    let writes = -1;
+    doc.transact(() => {
+      writes = writeChangedKeys(map.get("e2")!, { ...el });
+    });
+    expect(writes).toBe(0);
+  });
+
+  it("treats a JSON-leaf change (points) as one key write", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    const el = makeElement({ id: "e3", type: "line", points: [[0, 0]] });
+    doc.transact(() => map.set("e3", elementToYMap(el)));
+    let writes = 0;
+    doc.transact(() => {
+      writes = writeChangedKeys(map.get("e3")!, {
+        ...el,
+        points: [
+          [0, 0],
+          [5, 5],
+        ],
+      });
+    });
+    expect(writes).toBe(1);
+  });
+});
+
+describe("schema: deepEqual", () => {
+  it("compares nested objects/arrays by value, key-order-insensitive", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(deepEqual([1, [2, 3]], [1, [2, 3]])).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+});

--- a/packages/yjs-binding/tests/schema.test.ts
+++ b/packages/yjs-binding/tests/schema.test.ts
@@ -23,13 +23,28 @@ const roundtrip = (el: ElementRecord): ElementRecord => {
   return yMapToElement(map.get(el.id as string)!);
 };
 
+/**
+ * Strip the per-peer reconciliation metadata that is intentionally NOT synced
+ * through the doc (version/versionNonce/updated — RECONCILE_META_KEYS, Fix #1).
+ * The round-trip is lossless for every *synced* key; these three are re-derived
+ * locally on apply, so they never survive a doc round-trip.
+ */
+const withoutMeta = (el: ElementRecord): ElementRecord => {
+  const { version: _v, versionNonce: _n, updated: _u, ...rest } = el;
+  return rest;
+};
+
 describe("schema: element encode/decode (T003/T004)", () => {
   it("round-trips a base rectangle losslessly (scalars ===)", () => {
     const el = makeElement({ id: "r1", x: 5, y: 7, strokeColor: "#ff0000" });
     const back = roundtrip(el);
-    expect(back).toEqual(el);
+    // version/versionNonce/updated are reconciliation metadata, not synced.
+    expect(back).toEqual(withoutMeta(el));
     expect(back.x).toBe(5);
     expect(back.strokeColor).toBe("#ff0000");
+    expect("version" in back).toBe(false);
+    expect("versionNonce" in back).toBe(false);
+    expect("updated" in back).toBe(false);
   });
 
   it("round-trips a text element subtype fields", () => {
@@ -46,7 +61,7 @@ describe("schema: element encode/decode (T003/T004)", () => {
       lineHeight: 1.25,
       autoResize: true,
     });
-    expect(roundtrip(el)).toEqual(el);
+    expect(roundtrip(el)).toEqual(withoutMeta(el));
   });
 
   it("round-trips JSON-leaf props by deep value equality (points/groupIds/customData)", () => {
@@ -89,7 +104,23 @@ describe("schema: element encode/decode (T003/T004)", () => {
         naturalHeight: 20,
       },
     });
-    expect(roundtrip(el)).toEqual(el);
+    expect(roundtrip(el)).toEqual(withoutMeta(el));
+  });
+
+  it("does NOT sync version/versionNonce/updated through the doc (Fix #1)", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    const el = makeElement({
+      id: "meta1",
+      version: 42,
+      versionNonce: 99999,
+      updated: 1234567890,
+    });
+    doc.transact(() => map.set("meta1", elementToYMap(el)));
+    const ymap = map.get("meta1")!;
+    expect(ymap.has("version")).toBe(false);
+    expect(ymap.has("versionNonce")).toBe(false);
+    expect(ymap.has("updated")).toBe(false);
   });
 
   it("omits undefined keys (customData absent) for round-trip symmetry", () => {
@@ -191,6 +222,41 @@ describe("schema: writeChangedKeys per-property diff (T007)", () => {
       writes = writeChangedKeys(map.get("e2")!, { ...el });
     });
     expect(writes).toBe(0);
+  });
+
+  it("clears a property that went value → undefined (Fix #9)", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    const el = makeElement({ id: "c1", link: "https://example.com" });
+    doc.transact(() => map.set("c1", elementToYMap(el)));
+    const ymap = map.get("c1")!;
+    expect(ymap.get("link")).toBe("https://example.com");
+
+    let writes = 0;
+    doc.transact(() => {
+      writes = writeChangedKeys(ymap, { ...el, link: undefined });
+    });
+    expect(writes).toBe(1);
+    // the stale value must be removed, not left to resurrect on round-trip
+    expect(ymap.has("link")).toBe(false);
+    expect("link" in yMapToElement(ymap)).toBe(false);
+  });
+
+  it("clears a property that was dropped from the element entirely (Fix #9)", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    const el = makeElement({ id: "c2", link: "https://example.com" });
+    doc.transact(() => map.set("c2", elementToYMap(el)));
+    const ymap = map.get("c2")!;
+
+    const dropped = { ...el };
+    delete dropped.link;
+    let writes = 0;
+    doc.transact(() => {
+      writes = writeChangedKeys(ymap, dropped);
+    });
+    expect(writes).toBe(1);
+    expect(ymap.has("link")).toBe(false);
   });
 
   it("treats a JSON-leaf change (points) as one key write", () => {

--- a/packages/yjs-binding/tests/units.test.ts
+++ b/packages/yjs-binding/tests/units.test.ts
@@ -63,6 +63,79 @@ describe("files: diff add/change/remove + readFiles (T009)", () => {
   });
 });
 
+describe("files: deletion guard during async load / tombstones (Fix #3)", () => {
+  const makeRoots = () => {
+    const doc = new Y.Doc();
+    return {
+      ydoc: doc,
+      elementsMap: doc.getMap<Y.Map<unknown>>("elements"),
+      filesMap: doc.getMap<BinaryFileData>("files"),
+      appStateMap: doc.getMap<unknown>("appState"),
+    };
+  };
+
+  it("keeps a binary referenced by a tombstoned image element", () => {
+    const roots = makeRoots();
+    const img = makeElement({
+      id: "img",
+      type: "image",
+      fileId: "f1",
+      index: "a1",
+    });
+    writeDiff(roots, [], [img], undefined, {
+      f1: file("f1", "BYTES"),
+    } as BinaryFiles);
+    expect(roots.filesMap.has("f1")).toBe(true);
+
+    // Soft-delete the image (removed from the next array → tombstone). A benign
+    // local onChange then fires WITHOUT the file in its files arg (the editor no
+    // longer lists deleted-image binaries). The file must survive — the
+    // tombstone still references it.
+    writeDiff(roots, [img], []); // tombstone
+    writeDiff(
+      roots,
+      [],
+      [{ ...img, isDeleted: true }],
+      undefined,
+      {} as BinaryFiles,
+    );
+    expect(roots.filesMap.has("f1")).toBe(true);
+  });
+
+  it("does not delete a binary while its image element exists but files is transiently partial", () => {
+    const roots = makeRoots();
+    const img = makeElement({
+      id: "img",
+      type: "image",
+      fileId: "f1",
+      index: "a1",
+    });
+    writeDiff(roots, [], [img], undefined, {
+      f1: file("f1", "BYTES"),
+    } as BinaryFiles);
+
+    // An onChange arrives mid async-load: the element is still present but the
+    // files arg is empty (binary not yet (re)loaded into the editor cache).
+    const writes = writeDiff(roots, [img], [img], undefined, {} as BinaryFiles);
+    expect(writes).toBe(0); // nothing to do — file is protected
+    expect(roots.filesMap.has("f1")).toBe(true);
+  });
+
+  it("still deletes a truly unreferenced binary", () => {
+    const roots = makeRoots();
+    const el = makeElement({ id: "shape", index: "a1" }); // no fileId
+    writeDiff(roots, [], [el], undefined, {
+      orphan: file("orphan", "X"),
+    } as BinaryFiles);
+    expect(roots.filesMap.has("orphan")).toBe(true);
+
+    // No element references "orphan" and it is absent from files → delete it.
+    const writes = writeDiff(roots, [el], [el], undefined, {} as BinaryFiles);
+    expect(writes).toBeGreaterThan(0);
+    expect(roots.filesMap.has("orphan")).toBe(false);
+  });
+});
+
 describe("apply: new files propagate to the editor via addFiles", () => {
   it("addFiles is called for binaries the editor lacks", () => {
     const doc = new Y.Doc();
@@ -81,6 +154,32 @@ describe("apply: new files propagate to the editor via addFiles", () => {
     Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote));
 
     expect(api.files.f1).toBeDefined();
+
+    binding.destroy();
+  });
+
+  it("re-applies an existing fileId whose bytes changed in the doc (Fix #2)", () => {
+    const doc = new Y.Doc();
+    const remote = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    api.emitChange([
+      makeElement({ id: "img", type: "image", fileId: "f1", index: "a1" }),
+    ]);
+    sync(doc, remote);
+
+    // First version of the binary arrives.
+    const fmap = remote.getMap<BinaryFileData>("files");
+    remote.transact(() => fmap.set("f1", file("f1", "ORIGINAL")));
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote));
+    expect((api.files.f1 as BinaryFileData).dataURL).toBe("ORIGINAL");
+
+    // The SAME fileId is replaced with new bytes (image replacement). Before the
+    // fix this was dropped because the id already existed locally.
+    remote.transact(() => fmap.set("f1", file("f1", "REPLACED")));
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote));
+    expect((api.files.f1 as BinaryFileData).dataURL).toBe("REPLACED");
 
     binding.destroy();
   });

--- a/packages/yjs-binding/tests/units.test.ts
+++ b/packages/yjs-binding/tests/units.test.ts
@@ -1,0 +1,255 @@
+import { Awareness } from "y-protocols/awareness";
+import { describe, expect, it, vi } from "vitest";
+
+import type { BinaryFileData, BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import { diffFiles, readFiles } from "../src/files";
+import { AwarenessRouter } from "../src/awareness";
+import { nonDeleted } from "../src/apply";
+import { writeDiff, areElementsSame } from "../src/diff";
+
+import {
+  StubExcalidrawAPI,
+  WhiteboardBinding,
+  Y,
+  makeElement,
+  sync,
+} from "./helpers";
+
+import type { EphemeralChannel, EphemeralEvent } from "../src/awareness";
+import type { ElementRecord } from "../src/schema";
+
+const file = (id: string, dataURL: string): BinaryFileData =>
+  ({
+    id,
+    mimeType: "image/png",
+    dataURL,
+    created: 1,
+  } as unknown as BinaryFileData);
+
+describe("files: diff add/change/remove + readFiles (T009)", () => {
+  it("appends, updates, and removes files", () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<BinaryFileData>("files");
+
+    let mutations = 0;
+    doc.transact(() => {
+      mutations = diffFiles(map, { a: file("a", "AAA") } as BinaryFiles);
+    });
+    expect(mutations).toBe(1);
+    expect(readFiles(map)).toEqual({ a: file("a", "AAA") });
+
+    // change a, add b
+    doc.transact(() => {
+      mutations = diffFiles(map, {
+        a: file("a", "BBB"),
+        b: file("b", "CCC"),
+      } as BinaryFiles);
+    });
+    expect(mutations).toBe(2);
+
+    // remove a
+    doc.transact(() => {
+      mutations = diffFiles(map, { b: file("b", "CCC") } as BinaryFiles);
+    });
+    expect(mutations).toBe(1);
+    expect(Object.keys(readFiles(map))).toEqual(["b"]);
+
+    // no-op
+    doc.transact(() => {
+      mutations = diffFiles(map, { b: file("b", "CCC") } as BinaryFiles);
+    });
+    expect(mutations).toBe(0);
+  });
+});
+
+describe("apply: new files propagate to the editor via addFiles", () => {
+  it("addFiles is called for binaries the editor lacks", () => {
+    const doc = new Y.Doc();
+    const remote = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    api.emitChange([
+      makeElement({ id: "img", type: "image", fileId: "f1", index: "a1" }),
+    ]);
+    sync(doc, remote);
+
+    // A remote file lands in the doc.
+    const fmap = remote.getMap<BinaryFileData>("files");
+    remote.transact(() => fmap.set("f1", file("f1", "ZZZ")));
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(remote));
+
+    expect(api.files.f1).toBeDefined();
+
+    binding.destroy();
+  });
+});
+
+describe("apply: buildElements seeds version metadata for first-seen elements", () => {
+  it("assigns version/versionNonce when the doc element lacks them", async () => {
+    const { buildElements } = await import("../src/apply");
+    const doc = new Y.Doc();
+    const map = doc.getMap<Y.Map<unknown>>("elements");
+    doc.transact(() => {
+      const ymap = new Y.Map<unknown>();
+      map.set("v", ymap);
+      ymap.set("id", "v");
+      ymap.set("index", "a1");
+      // deliberately NO version / versionNonce
+    });
+    const { elements } = buildElements(map, new Map());
+    const el = elements.find((e) => e.id === "v")!;
+    expect(typeof el.version).toBe("number");
+    expect(typeof el.versionNonce).toBe("number");
+  });
+});
+
+describe("apply: nonDeleted filter", () => {
+  it("filters tombstones", () => {
+    const els: ElementRecord[] = [
+      makeElement({ id: "a" }),
+      makeElement({ id: "b", isDeleted: true }),
+    ];
+    expect(nonDeleted(els).map((e) => e.id)).toEqual(["a"]);
+  });
+});
+
+describe("diff: areElementsSame edge cases", () => {
+  it("detects length change and id/version change", () => {
+    const a = [makeElement({ id: "x", version: 1 })];
+    expect(areElementsSame(a, [])).toBe(false);
+    expect(areElementsSame(a, [makeElement({ id: "x", version: 2 })])).toBe(
+      false,
+    );
+    expect(areElementsSame(a, [makeElement({ id: "y", version: 1 })])).toBe(
+      false,
+    );
+    const same = [{ ...a[0] }];
+    expect(areElementsSame(a, same)).toBe(true);
+  });
+});
+
+describe("diff: boundElements change detection in hasDiffWork", () => {
+  it("a boundElements-only change still triggers a write", () => {
+    const doc = new Y.Doc();
+    const roots = {
+      ydoc: doc,
+      elementsMap: doc.getMap<Y.Map<unknown>>("elements"),
+      filesMap: doc.getMap<BinaryFileData>("files"),
+      appStateMap: doc.getMap<unknown>("appState"),
+    };
+    const el = makeElement({ id: "n", index: "a1", boundElements: null });
+    writeDiff(roots, [], [el]);
+
+    // bump version (editor would) + add a binding
+    const edited: ElementRecord = {
+      ...el,
+      version: 2,
+      boundElements: [{ id: "arr", type: "arrow" }],
+    };
+    const writes = writeDiff(roots, [el], [edited]);
+    expect(writes).toBeGreaterThan(0);
+    const nested = roots.elementsMap
+      .get("n")!
+      .get("boundElements") as Y.Map<string>;
+    expect(nested.has("arr")).toBe(true);
+  });
+});
+
+const makeChannel = () => {
+  const handlers = new Set<(e: EphemeralEvent) => void>();
+  const channel: EphemeralChannel = {
+    send: (event) => handlers.forEach((h) => h(event)),
+    subscribe: (handler) => {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+  };
+  return channel;
+};
+
+describe("awareness: selection/idle/user/bounds routing", () => {
+  it("routes selection, idle, user to awareness fields", () => {
+    const awareness = new Awareness(new Y.Doc());
+    const api = new StubExcalidrawAPI();
+    const router = new AwarenessRouter({
+      awareness,
+      api: api.routerApi(),
+    });
+
+    router.onSelectionChange({ el1: true });
+    router.onIdleChange("active");
+    router.setUser({ username: "alice" });
+
+    const state = awareness.getLocalState()!;
+    expect(state.selectedElementIds).toEqual({ el1: true });
+    expect(state.userState).toBe("active");
+    expect(state.user).toEqual({ username: "alice" });
+
+    router.destroy();
+  });
+
+  it("an incoming USER_VISIBLE_SCENE_BOUNDS event is a no-op dispatch (host consumes it)", () => {
+    const awareness = new Awareness(new Y.Doc());
+    const api = new StubExcalidrawAPI();
+    const channel = makeChannel();
+    const router = new AwarenessRouter({
+      awareness,
+      api: api.routerApi(),
+      ephemeral: channel,
+    });
+
+    expect(() =>
+      router.broadcastVisibleSceneBounds({ sceneBounds: [0, 0, 1, 1] }),
+    ).not.toThrow();
+    // no emoji/countdown dispatched by a bounds event
+    expect(api.dispatchedEmoji).toHaveLength(0);
+    expect(api.dispatchedCountdown).toHaveLength(0);
+
+    router.destroy();
+  });
+
+  it("broadcast helpers no-op when no ephemeral channel is configured", () => {
+    const awareness = new Awareness(new Y.Doc());
+    const api = new StubExcalidrawAPI();
+    const router = new AwarenessRouter({
+      awareness,
+      api: api.routerApi(),
+    });
+    expect(() =>
+      router.broadcastEmojiReaction({ id: "e", emoji: "x", x: 0, y: 0 }),
+    ).not.toThrow();
+    router.destroy();
+  });
+});
+
+describe("binding lifecycle: destroy detaches + is idempotent", () => {
+  it("destroy stops further onChange processing and double-destroy is safe", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI());
+
+    binding.destroy();
+    const spy = vi.spyOn(doc, "transact");
+    api.emitChange([makeElement({ id: "after", index: "a1" })]);
+    // no writes after destroy
+    expect(spy).not.toHaveBeenCalled();
+    expect(() => binding.destroy()).not.toThrow();
+    spy.mockRestore();
+  });
+
+  it("seeds an empty doc from an initial scene", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: {
+        elements: [makeElement({ id: "seed", index: "a1" })],
+        appState: { viewBackgroundColor: "#abcabc", name: "Seeded" },
+      },
+    });
+    expect(doc.getMap("elements").has("seed")).toBe(true);
+    expect(doc.getMap("appState").get("viewBackgroundColor")).toBe("#abcabc");
+    binding.destroy();
+  });
+});

--- a/packages/yjs-binding/tsconfig.json
+++ b/packages/yjs-binding/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/types"
+  },
+  "include": ["src/**/*", "global.d.ts"],
+  "exclude": ["**/*.test.*", "tests", "types", "examples", "dist"]
+}

--- a/specs/001-yjs-per-property-binding/tasks.md
+++ b/specs/001-yjs-per-property-binding/tasks.md
@@ -13,11 +13,11 @@
 
 ## Phase 1: Setup & schema
 
-- [X] T001 Scaffold `packages/yjs-binding/` package: `package.json` (deps `yjs`, `y-protocols`, `@excalidraw/element`, `@excalidraw/fractional-indexing`), `tsconfig.json`, build wiring matching the monorepo's other packages. (`packages/yjs-binding/package.json`)
-- [X] T002 Define root-name constants and the origin sentinel: `ELEMENTS`, `FILES`, `APPSTATE` (synced allow-list `viewBackgroundColor`, `name` — OPEN-2 resolved), and a unique `BINDING_ORIGIN` object. (`packages/yjs-binding/src/origin.ts`, `src/schema.ts`)
-- [X] T003 [US1] Implement `elementToYMap(element)` / `yMapToElement(ymap)` encode/decode honoring the representation tiering (scalars as plain values; JSON-leaf for `points`, `pressures`, `groupIds`, `roundness`, `startBinding`/`endBinding`/`fixedSegments`, `scale`, `crop`, `customData`; **`boundElements` → nested `Y.Map<id,"arrow"|"text">` add/remove set per §4.1**) per data-model §2/§4. Derive keys from the live element object, not a hand-list. (`packages/yjs-binding/src/schema.ts`)
-- [X] T004 Add unit tests for `schema.ts`: every base + subtype field round-trips; JSON-leaf deep-equal; scalars `===`. (`packages/yjs-binding/tests/schema.test.ts`)
-- [X] T005 [P] [US3] Implement order helpers wrapping `@excalidraw/fractional-indexing`: `orderByIndex`, `keyBetween(prev,next)`, `repairIndices` (= `syncInvalidIndices`). No bespoke ordering. (`packages/yjs-binding/src/order.ts`) — data-model §3
+- [x] T001 Scaffold `packages/yjs-binding/` package: `package.json` (deps `yjs`, `y-protocols`, `@excalidraw/element`, `@excalidraw/fractional-indexing`), `tsconfig.json`, build wiring matching the monorepo's other packages. (`packages/yjs-binding/package.json`)
+- [x] T002 Define root-name constants and the origin sentinel: `ELEMENTS`, `FILES`, `APPSTATE` (synced allow-list `viewBackgroundColor`, `name` — OPEN-2 resolved), and a unique `BINDING_ORIGIN` object. (`packages/yjs-binding/src/origin.ts`, `src/schema.ts`)
+- [x] T003 [US1] Implement `elementToYMap(element)` / `yMapToElement(ymap)` encode/decode honoring the representation tiering (scalars as plain values; JSON-leaf for `points`, `pressures`, `groupIds`, `roundness`, `startBinding`/`endBinding`/`fixedSegments`, `scale`, `crop`, `customData`; **`boundElements` → nested `Y.Map<id,"arrow"|"text">` add/remove set per §4.1**) per data-model §2/§4. Derive keys from the live element object, not a hand-list. (`packages/yjs-binding/src/schema.ts`)
+- [x] T004 Add unit tests for `schema.ts`: every base + subtype field round-trips; JSON-leaf deep-equal; scalars `===`. (`packages/yjs-binding/tests/schema.test.ts`)
+- [x] T005 [P] [US3] Implement order helpers wrapping `@excalidraw/fractional-indexing`: `orderByIndex`, `keyBetween(prev,next)`, `repairIndices` (= `syncInvalidIndices`). No bespoke ordering. (`packages/yjs-binding/src/order.ts`) — data-model §3
 
 **Checkpoint**: an element converts losslessly to/from its `Y.Map`; ordering primitives exist.
 
@@ -25,11 +25,11 @@
 
 ## Phase 2: onChange → Y write path (US1/US2)
 
-- [X] T006 [US2] Implement the cheap change gate `areElementsSame(prev, next)` comparing `(id, version)` pairs (fast path to skip no-op `onChange`s). (`packages/yjs-binding/src/diff.ts`) — data-model §8 Diff
-- [X] T007 [US1] Implement per-element **per-property** delta computation: for an existing element write only changed keys (deep-compare JSON-leaf, `===` scalars; **`boundElements` diffs into its nested `Y.Map` via `set(id,type)`/`delete(id)`, §4.1**); for a new element write all keys + `keyBetween` `index`; for a removed element set `isDeleted=true` (tombstone, never `Y.Map.delete`). Also diff the `APPSTATE` allow-list (`viewBackgroundColor`, `name`) on local change. (`packages/yjs-binding/src/diff.ts`) — FR-B-001/002/006
-- [X] T008 [US1] Apply all element writes in **one** `ydoc.transact(fn, BINDING_ORIGIN)`; update `lastKnownElements`. (`packages/yjs-binding/src/diff.ts`) — FR-B-002
-- [X] T009 [P] [US1] Implement files diff in a separate map: append new `BinaryFileData`, remove dropped ids, origin-tagged. (`packages/yjs-binding/src/files.ts`) — FR-B-007
-- [X] T010 [US2] Add tests: a single-property change emits exactly one transaction writing exactly one key; a no-op `onChange` emits no transaction. (`packages/yjs-binding/tests/echo.test.ts`)
+- [x] T006 [US2] Implement the cheap change gate `areElementsSame(prev, next)` comparing `(id, version)` pairs (fast path to skip no-op `onChange`s). (`packages/yjs-binding/src/diff.ts`) — data-model §8 Diff
+- [x] T007 [US1] Implement per-element **per-property** delta computation: for an existing element write only changed keys (deep-compare JSON-leaf, `===` scalars; **`boundElements` diffs into its nested `Y.Map` via `set(id,type)`/`delete(id)`, §4.1**); for a new element write all keys + `keyBetween` `index`; for a removed element set `isDeleted=true` (tombstone, never `Y.Map.delete`). Also diff the `APPSTATE` allow-list (`viewBackgroundColor`, `name`) on local change. (`packages/yjs-binding/src/diff.ts`) — FR-B-001/002/006
+- [x] T008 [US1] Apply all element writes in **one** `ydoc.transact(fn, BINDING_ORIGIN)`; update `lastKnownElements`. (`packages/yjs-binding/src/diff.ts`) — FR-B-002
+- [x] T009 [P] [US1] Implement files diff in a separate map: append new `BinaryFileData`, remove dropped ids, origin-tagged. (`packages/yjs-binding/src/files.ts`) — FR-B-007
+- [x] T010 [US2] Add tests: a single-property change emits exactly one transaction writing exactly one key; a no-op `onChange` emits no transaction. (`packages/yjs-binding/tests/echo.test.ts`)
 
 **Checkpoint**: local edits produce minimal, origin-tagged per-property Yjs writes.
 
@@ -37,12 +37,12 @@
 
 ## Phase 3: Y observe → scene apply path (US3)
 
-- [X] T011 [US3] Implement scene `observeDeep` + files `observe`; on each event, **echo-guard** `if (transaction.origin === BINDING_ORIGIN) return`. (`packages/yjs-binding/src/apply.ts`) — FR-B-004
-- [X] T012 [US3] Rebuild only affected elements from their `Y.Map`s; reuse unchanged local elements; do not rebuild the whole scene (O(changed)). (`packages/yjs-binding/src/apply.ts`) — NFR-B-001
-- [X] T013 [US3] Order applied elements by `index` (`orderByIndex`) and run `repairIndices` for concurrent equal-index collisions (write repairs back under `BINDING_ORIGIN`). (`packages/yjs-binding/src/apply.ts`) — data-model §3, US3-AC3
-- [X] T014 [US3] Filter tombstones for render (`getNonDeletedElements`) while retaining them in the doc; honor merged `isDeleted`. (`packages/yjs-binding/src/apply.ts`) — FR-B-006, US1-AC3
-- [X] T015 [US2] Implement the "actively editing" guard: skip replacing an element the local user is mid-editing (text edit / resize / new element), mirroring `shouldDiscardRemoteElement`'s editing checks. (`packages/yjs-binding/src/apply.ts`) — FR-B-013
-- [X] T016 [US2] Call `api.updateScene({ elements, captureUpdate: CaptureUpdateAction.NEVER })`; apply the synced `APPSTATE` allow-list (`viewBackgroundColor`, `name`) from the doc; preserve local-only `appState` (selection/zoom/scroll/tool). (`packages/yjs-binding/src/apply.ts`) — FR-B-003
+- [x] T011 [US3] Implement scene `observeDeep` + files `observe`; on each event, **echo-guard** `if (transaction.origin === BINDING_ORIGIN) return`. (`packages/yjs-binding/src/apply.ts`) — FR-B-004
+- [x] T012 [US3] Rebuild only affected elements from their `Y.Map`s; reuse unchanged local elements; do not rebuild the whole scene (O(changed)). (`packages/yjs-binding/src/apply.ts`) — NFR-B-001
+- [x] T013 [US3] Order applied elements by `index` (`orderByIndex`) and run `repairIndices` for concurrent equal-index collisions (write repairs back under `BINDING_ORIGIN`). (`packages/yjs-binding/src/apply.ts`) — data-model §3, US3-AC3
+- [x] T014 [US3] Filter tombstones for render (`getNonDeletedElements`) while retaining them in the doc; honor merged `isDeleted`. (`packages/yjs-binding/src/apply.ts`) — FR-B-006, US1-AC3
+- [x] T015 [US2] Implement the "actively editing" guard: skip replacing an element the local user is mid-editing (text edit / resize / new element), mirroring `shouldDiscardRemoteElement`'s editing checks. (`packages/yjs-binding/src/apply.ts`) — FR-B-013
+- [x] T016 [US2] Call `api.updateScene({ elements, captureUpdate: CaptureUpdateAction.NEVER })`; apply the synced `APPSTATE` allow-list (`viewBackgroundColor`, `name`) from the doc; preserve local-only `appState` (selection/zoom/scroll/tool). (`packages/yjs-binding/src/apply.ts`) — FR-B-003
 
 **Checkpoint**: remote per-property changes render in correct order with tombstones, no echo, no lost local selection.
 
@@ -50,34 +50,34 @@
 
 ## Phase 4: Loop guard & binding lifecycle
 
-- [X] T017 [US2] Wire it together in `WhiteboardBinding`: constructor `(ydoc, api, awareness?)` attaches `api.onChange`→diff and the observers→apply; seeds `lastKnownElements` from the doc. (`packages/yjs-binding/src/index.ts`) — FR-B-011
-- [X] T018 [US2] Implement `destroy()` detaching every observer + `onChange`/awareness subscription; null caches; no leaks on remount. (`packages/yjs-binding/src/index.ts`) — FR-B-012
-- [X] T019 [US2] Echo regression test: a full local-edit → write → own-observe cycle triggers **zero** re-entrant `updateScene`. (`packages/yjs-binding/tests/echo.test.ts`) — SC-B-003
+- [x] T017 [US2] Wire it together in `WhiteboardBinding`: constructor `(ydoc, api, awareness?)` attaches `api.onChange`→diff and the observers→apply; seeds `lastKnownElements` from the doc. (`packages/yjs-binding/src/index.ts`) — FR-B-011
+- [x] T018 [US2] Implement `destroy()` detaching every observer + `onChange`/awareness subscription; null caches; no leaks on remount. (`packages/yjs-binding/src/index.ts`) — FR-B-012
+- [x] T019 [US2] Echo regression test: a full local-edit → write → own-observe cycle triggers **zero** re-entrant `updateScene`. (`packages/yjs-binding/tests/echo.test.ts`) — SC-B-003
 
 ---
 
 ## Phase 5: Awareness / ephemeral routing (US4 — FR-008)
 
-- [X] T020 [US4] Route cursor/pointer (`onPointerUpdate`), selection, and idle to `awareness.setLocalStateField`; surface remote awareness via `api.updateScene({ collaborators })` (no element mutation). (`packages/yjs-binding/src/awareness.ts`) — FR-B-008, data-model §7
-- [X] T021 [US4] Route emoji reactions / countdown timer / visible-scene-bounds to the **ephemeral** channel and dispatch incoming via `dispatchIncomingEmojiReaction` / `dispatchIncomingCountdownTimer`; **never** touch the scene doc. (`packages/yjs-binding/src/awareness.ts`) — FR-B-008
-- [X] T022 [US4] Awareness isolation test: a burst of pointer/emoji/countdown events produces **zero** scene-doc transactions and the scene snapshot is byte-identical before/after. (`packages/yjs-binding/tests/awareness.test.ts`) — SC-B-004
+- [x] T020 [US4] Route cursor/pointer (`onPointerUpdate`), selection, and idle to `awareness.setLocalStateField`; surface remote awareness via `api.updateScene({ collaborators })` (no element mutation). (`packages/yjs-binding/src/awareness.ts`) — FR-B-008, data-model §7
+- [x] T021 [US4] Route emoji reactions / countdown timer / visible-scene-bounds to the **ephemeral** channel and dispatch incoming via `dispatchIncomingEmojiReaction` / `dispatchIncomingCountdownTimer`; **never** touch the scene doc. (`packages/yjs-binding/src/awareness.ts`) — FR-B-008
+- [x] T022 [US4] Awareness isolation test: a burst of pointer/emoji/countdown events produces **zero** scene-doc transactions and the scene snapshot is byte-identical before/after. (`packages/yjs-binding/tests/awareness.test.ts`) — SC-B-004
 
 ---
 
 ## Phase 6: Migration round-trip (US5 — FR-B-010)
 
-- [X] T023 [US5] Implement `populateYDoc(sceneJSON, ydoc)`: write every element to the scene map (tombstones included), files to the files map; repair missing/invalid `index`. (`packages/yjs-binding/src/migrate.ts`) — data-model §6
-- [X] T024 [US5] Implement `exportSceneJSON(ydoc)`: read back to an Excalidraw scene (ordered by `index`). (`packages/yjs-binding/src/migrate.ts`)
-- [X] T025 [US5] Round-trip test: representative scene (text+arrow `points`+image `fileId`+grouped+soft-deleted+`customData`+bound text/arrows) is deep-equal modulo the §6 normalization rules. (`packages/yjs-binding/tests/roundtrip.test.ts`) — SC-B-005
+- [x] T023 [US5] Implement `populateYDoc(sceneJSON, ydoc)`: write every element to the scene map (tombstones included), files to the files map; repair missing/invalid `index`. (`packages/yjs-binding/src/migrate.ts`) — data-model §6
+- [x] T024 [US5] Implement `exportSceneJSON(ydoc)`: read back to an Excalidraw scene (ordered by `index`). (`packages/yjs-binding/src/migrate.ts`)
+- [x] T025 [US5] Round-trip test: representative scene (text+arrow `points`+image `fileId`+grouped+soft-deleted+`customData`+bound text/arrows) is deep-equal modulo the §6 normalization rules. (`packages/yjs-binding/tests/roundtrip.test.ts`) — SC-B-005
 
 ---
 
 ## Phase 7: Convergence component tests + WS-F contribution (US1 — SC-B-001/002)
 
-- [X] T026 [US1] Two-`Y.Doc` merge test: bindings A/B on one element; A sets position, B sets `strokeColor` while partitioned; exchange updates; assert both scenes carry both edits. (`packages/yjs-binding/tests/merge.test.ts`) — SC-B-001
-- [X] T027 [P] [US1] Same-property tiebreak test: A and B set the same key differently; after sync both converge to one deterministic value, no divergence/exception. (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC2
-- [X] T028 [P] [US1] Delete-vs-edit test: A tombstones an element while B edits a property; converge to a single consistent outcome (tombstone wins render, edit retained). (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC3
-- [X] T029 [P] [US3] Concurrent order test: A and B insert elements that pick equal fractional `index`; `repairIndices` converges both to identical order. (`packages/yjs-binding/tests/apply-order.test.ts`) — US3-AC3
+- [x] T026 [US1] Two-`Y.Doc` merge test: bindings A/B on one element; A sets position, B sets `strokeColor` while partitioned; exchange updates; assert both scenes carry both edits. (`packages/yjs-binding/tests/merge.test.ts`) — SC-B-001
+- [x] T027 [P] [US1] Same-property tiebreak test: A and B set the same key differently; after sync both converge to one deterministic value, no divergence/exception. (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC2
+- [x] T028 [P] [US1] Delete-vs-edit test: A tombstones an element while B edits a property; converge to a single consistent outcome (tombstone wins render, edit retained). (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC3
+- [x] T029 [P] [US3] Concurrent order test: A and B insert elements that pick equal fractional `index`; `repairIndices` converges both to identical order. (`packages/yjs-binding/tests/apply-order.test.ts`) — US3-AC3
 - [~] T030 Contribute the two-doc convergence + awareness-isolation scenarios to the shared WS-F e2e harness; ensure the package's coverage gate (≥95%) is wired into CI. (cross-repo: WS-F harness; `packages/yjs-binding` CI) — SC-B-006 / epic SC-008/SC-009
   - **In-repo part DONE**: the two-doc convergence scenarios (`merge.test.ts`) and awareness-isolation scenario (`awareness.test.ts`) exist and pass; package coverage measured at **97.7% statements / 100% functions** (above the ≥95% gate) via `vitest run --coverage`.
   - **Deferred (cross-repo)**: contributing these scenarios to the shared **WS-F** e2e harness and wiring the ≥95% threshold into the repo's CI workflow live outside this package and are owned by WS-F. Not done here.

--- a/specs/001-yjs-per-property-binding/tasks.md
+++ b/specs/001-yjs-per-property-binding/tasks.md
@@ -13,11 +13,11 @@
 
 ## Phase 1: Setup & schema
 
-- [ ] T001 Scaffold `packages/yjs-binding/` package: `package.json` (deps `yjs`, `y-protocols`, `@excalidraw/element`, `@excalidraw/fractional-indexing`), `tsconfig.json`, build wiring matching the monorepo's other packages. (`packages/yjs-binding/package.json`)
-- [ ] T002 Define root-name constants and the origin sentinel: `ELEMENTS`, `FILES`, `APPSTATE` (synced allow-list `viewBackgroundColor`, `name` — OPEN-2 resolved), and a unique `BINDING_ORIGIN` object. (`packages/yjs-binding/src/origin.ts`, `src/schema.ts`)
-- [ ] T003 [US1] Implement `elementToYMap(element)` / `yMapToElement(ymap)` encode/decode honoring the representation tiering (scalars as plain values; JSON-leaf for `points`, `pressures`, `groupIds`, `roundness`, `startBinding`/`endBinding`/`fixedSegments`, `scale`, `crop`, `customData`; **`boundElements` → nested `Y.Map<id,"arrow"|"text">` add/remove set per §4.1**) per data-model §2/§4. Derive keys from the live element object, not a hand-list. (`packages/yjs-binding/src/schema.ts`)
-- [ ] T004 Add unit tests for `schema.ts`: every base + subtype field round-trips; JSON-leaf deep-equal; scalars `===`. (`packages/yjs-binding/tests/schema.test.ts`)
-- [ ] T005 [P] [US3] Implement order helpers wrapping `@excalidraw/fractional-indexing`: `orderByIndex`, `keyBetween(prev,next)`, `repairIndices` (= `syncInvalidIndices`). No bespoke ordering. (`packages/yjs-binding/src/order.ts`) — data-model §3
+- [X] T001 Scaffold `packages/yjs-binding/` package: `package.json` (deps `yjs`, `y-protocols`, `@excalidraw/element`, `@excalidraw/fractional-indexing`), `tsconfig.json`, build wiring matching the monorepo's other packages. (`packages/yjs-binding/package.json`)
+- [X] T002 Define root-name constants and the origin sentinel: `ELEMENTS`, `FILES`, `APPSTATE` (synced allow-list `viewBackgroundColor`, `name` — OPEN-2 resolved), and a unique `BINDING_ORIGIN` object. (`packages/yjs-binding/src/origin.ts`, `src/schema.ts`)
+- [X] T003 [US1] Implement `elementToYMap(element)` / `yMapToElement(ymap)` encode/decode honoring the representation tiering (scalars as plain values; JSON-leaf for `points`, `pressures`, `groupIds`, `roundness`, `startBinding`/`endBinding`/`fixedSegments`, `scale`, `crop`, `customData`; **`boundElements` → nested `Y.Map<id,"arrow"|"text">` add/remove set per §4.1**) per data-model §2/§4. Derive keys from the live element object, not a hand-list. (`packages/yjs-binding/src/schema.ts`)
+- [X] T004 Add unit tests for `schema.ts`: every base + subtype field round-trips; JSON-leaf deep-equal; scalars `===`. (`packages/yjs-binding/tests/schema.test.ts`)
+- [X] T005 [P] [US3] Implement order helpers wrapping `@excalidraw/fractional-indexing`: `orderByIndex`, `keyBetween(prev,next)`, `repairIndices` (= `syncInvalidIndices`). No bespoke ordering. (`packages/yjs-binding/src/order.ts`) — data-model §3
 
 **Checkpoint**: an element converts losslessly to/from its `Y.Map`; ordering primitives exist.
 
@@ -25,11 +25,11 @@
 
 ## Phase 2: onChange → Y write path (US1/US2)
 
-- [ ] T006 [US2] Implement the cheap change gate `areElementsSame(prev, next)` comparing `(id, version)` pairs (fast path to skip no-op `onChange`s). (`packages/yjs-binding/src/diff.ts`) — data-model §8 Diff
-- [ ] T007 [US1] Implement per-element **per-property** delta computation: for an existing element write only changed keys (deep-compare JSON-leaf, `===` scalars; **`boundElements` diffs into its nested `Y.Map` via `set(id,type)`/`delete(id)`, §4.1**); for a new element write all keys + `keyBetween` `index`; for a removed element set `isDeleted=true` (tombstone, never `Y.Map.delete`). Also diff the `APPSTATE` allow-list (`viewBackgroundColor`, `name`) on local change. (`packages/yjs-binding/src/diff.ts`) — FR-B-001/002/006
-- [ ] T008 [US1] Apply all element writes in **one** `ydoc.transact(fn, BINDING_ORIGIN)`; update `lastKnownElements`. (`packages/yjs-binding/src/diff.ts`) — FR-B-002
-- [ ] T009 [P] [US1] Implement files diff in a separate map: append new `BinaryFileData`, remove dropped ids, origin-tagged. (`packages/yjs-binding/src/files.ts`) — FR-B-007
-- [ ] T010 [US2] Add tests: a single-property change emits exactly one transaction writing exactly one key; a no-op `onChange` emits no transaction. (`packages/yjs-binding/tests/echo.test.ts`)
+- [X] T006 [US2] Implement the cheap change gate `areElementsSame(prev, next)` comparing `(id, version)` pairs (fast path to skip no-op `onChange`s). (`packages/yjs-binding/src/diff.ts`) — data-model §8 Diff
+- [X] T007 [US1] Implement per-element **per-property** delta computation: for an existing element write only changed keys (deep-compare JSON-leaf, `===` scalars; **`boundElements` diffs into its nested `Y.Map` via `set(id,type)`/`delete(id)`, §4.1**); for a new element write all keys + `keyBetween` `index`; for a removed element set `isDeleted=true` (tombstone, never `Y.Map.delete`). Also diff the `APPSTATE` allow-list (`viewBackgroundColor`, `name`) on local change. (`packages/yjs-binding/src/diff.ts`) — FR-B-001/002/006
+- [X] T008 [US1] Apply all element writes in **one** `ydoc.transact(fn, BINDING_ORIGIN)`; update `lastKnownElements`. (`packages/yjs-binding/src/diff.ts`) — FR-B-002
+- [X] T009 [P] [US1] Implement files diff in a separate map: append new `BinaryFileData`, remove dropped ids, origin-tagged. (`packages/yjs-binding/src/files.ts`) — FR-B-007
+- [X] T010 [US2] Add tests: a single-property change emits exactly one transaction writing exactly one key; a no-op `onChange` emits no transaction. (`packages/yjs-binding/tests/echo.test.ts`)
 
 **Checkpoint**: local edits produce minimal, origin-tagged per-property Yjs writes.
 
@@ -37,12 +37,12 @@
 
 ## Phase 3: Y observe → scene apply path (US3)
 
-- [ ] T011 [US3] Implement scene `observeDeep` + files `observe`; on each event, **echo-guard** `if (transaction.origin === BINDING_ORIGIN) return`. (`packages/yjs-binding/src/apply.ts`) — FR-B-004
-- [ ] T012 [US3] Rebuild only affected elements from their `Y.Map`s; reuse unchanged local elements; do not rebuild the whole scene (O(changed)). (`packages/yjs-binding/src/apply.ts`) — NFR-B-001
-- [ ] T013 [US3] Order applied elements by `index` (`orderByIndex`) and run `repairIndices` for concurrent equal-index collisions (write repairs back under `BINDING_ORIGIN`). (`packages/yjs-binding/src/apply.ts`) — data-model §3, US3-AC3
-- [ ] T014 [US3] Filter tombstones for render (`getNonDeletedElements`) while retaining them in the doc; honor merged `isDeleted`. (`packages/yjs-binding/src/apply.ts`) — FR-B-006, US1-AC3
-- [ ] T015 [US2] Implement the "actively editing" guard: skip replacing an element the local user is mid-editing (text edit / resize / new element), mirroring `shouldDiscardRemoteElement`'s editing checks. (`packages/yjs-binding/src/apply.ts`) — FR-B-013
-- [ ] T016 [US2] Call `api.updateScene({ elements, captureUpdate: CaptureUpdateAction.NEVER })`; apply the synced `APPSTATE` allow-list (`viewBackgroundColor`, `name`) from the doc; preserve local-only `appState` (selection/zoom/scroll/tool). (`packages/yjs-binding/src/apply.ts`) — FR-B-003
+- [X] T011 [US3] Implement scene `observeDeep` + files `observe`; on each event, **echo-guard** `if (transaction.origin === BINDING_ORIGIN) return`. (`packages/yjs-binding/src/apply.ts`) — FR-B-004
+- [X] T012 [US3] Rebuild only affected elements from their `Y.Map`s; reuse unchanged local elements; do not rebuild the whole scene (O(changed)). (`packages/yjs-binding/src/apply.ts`) — NFR-B-001
+- [X] T013 [US3] Order applied elements by `index` (`orderByIndex`) and run `repairIndices` for concurrent equal-index collisions (write repairs back under `BINDING_ORIGIN`). (`packages/yjs-binding/src/apply.ts`) — data-model §3, US3-AC3
+- [X] T014 [US3] Filter tombstones for render (`getNonDeletedElements`) while retaining them in the doc; honor merged `isDeleted`. (`packages/yjs-binding/src/apply.ts`) — FR-B-006, US1-AC3
+- [X] T015 [US2] Implement the "actively editing" guard: skip replacing an element the local user is mid-editing (text edit / resize / new element), mirroring `shouldDiscardRemoteElement`'s editing checks. (`packages/yjs-binding/src/apply.ts`) — FR-B-013
+- [X] T016 [US2] Call `api.updateScene({ elements, captureUpdate: CaptureUpdateAction.NEVER })`; apply the synced `APPSTATE` allow-list (`viewBackgroundColor`, `name`) from the doc; preserve local-only `appState` (selection/zoom/scroll/tool). (`packages/yjs-binding/src/apply.ts`) — FR-B-003
 
 **Checkpoint**: remote per-property changes render in correct order with tombstones, no echo, no lost local selection.
 
@@ -50,35 +50,37 @@
 
 ## Phase 4: Loop guard & binding lifecycle
 
-- [ ] T017 [US2] Wire it together in `WhiteboardBinding`: constructor `(ydoc, api, awareness?)` attaches `api.onChange`→diff and the observers→apply; seeds `lastKnownElements` from the doc. (`packages/yjs-binding/src/index.ts`) — FR-B-011
-- [ ] T018 [US2] Implement `destroy()` detaching every observer + `onChange`/awareness subscription; null caches; no leaks on remount. (`packages/yjs-binding/src/index.ts`) — FR-B-012
-- [ ] T019 [US2] Echo regression test: a full local-edit → write → own-observe cycle triggers **zero** re-entrant `updateScene`. (`packages/yjs-binding/tests/echo.test.ts`) — SC-B-003
+- [X] T017 [US2] Wire it together in `WhiteboardBinding`: constructor `(ydoc, api, awareness?)` attaches `api.onChange`→diff and the observers→apply; seeds `lastKnownElements` from the doc. (`packages/yjs-binding/src/index.ts`) — FR-B-011
+- [X] T018 [US2] Implement `destroy()` detaching every observer + `onChange`/awareness subscription; null caches; no leaks on remount. (`packages/yjs-binding/src/index.ts`) — FR-B-012
+- [X] T019 [US2] Echo regression test: a full local-edit → write → own-observe cycle triggers **zero** re-entrant `updateScene`. (`packages/yjs-binding/tests/echo.test.ts`) — SC-B-003
 
 ---
 
 ## Phase 5: Awareness / ephemeral routing (US4 — FR-008)
 
-- [ ] T020 [US4] Route cursor/pointer (`onPointerUpdate`), selection, and idle to `awareness.setLocalStateField`; surface remote awareness via `api.updateScene({ collaborators })` (no element mutation). (`packages/yjs-binding/src/awareness.ts`) — FR-B-008, data-model §7
-- [ ] T021 [US4] Route emoji reactions / countdown timer / visible-scene-bounds to the **ephemeral** channel and dispatch incoming via `dispatchIncomingEmojiReaction` / `dispatchIncomingCountdownTimer`; **never** touch the scene doc. (`packages/yjs-binding/src/awareness.ts`) — FR-B-008
-- [ ] T022 [US4] Awareness isolation test: a burst of pointer/emoji/countdown events produces **zero** scene-doc transactions and the scene snapshot is byte-identical before/after. (`packages/yjs-binding/tests/awareness.test.ts`) — SC-B-004
+- [X] T020 [US4] Route cursor/pointer (`onPointerUpdate`), selection, and idle to `awareness.setLocalStateField`; surface remote awareness via `api.updateScene({ collaborators })` (no element mutation). (`packages/yjs-binding/src/awareness.ts`) — FR-B-008, data-model §7
+- [X] T021 [US4] Route emoji reactions / countdown timer / visible-scene-bounds to the **ephemeral** channel and dispatch incoming via `dispatchIncomingEmojiReaction` / `dispatchIncomingCountdownTimer`; **never** touch the scene doc. (`packages/yjs-binding/src/awareness.ts`) — FR-B-008
+- [X] T022 [US4] Awareness isolation test: a burst of pointer/emoji/countdown events produces **zero** scene-doc transactions and the scene snapshot is byte-identical before/after. (`packages/yjs-binding/tests/awareness.test.ts`) — SC-B-004
 
 ---
 
 ## Phase 6: Migration round-trip (US5 — FR-B-010)
 
-- [ ] T023 [US5] Implement `populateYDoc(sceneJSON, ydoc)`: write every element to the scene map (tombstones included), files to the files map; repair missing/invalid `index`. (`packages/yjs-binding/src/migrate.ts`) — data-model §6
-- [ ] T024 [US5] Implement `exportSceneJSON(ydoc)`: read back to an Excalidraw scene (ordered by `index`). (`packages/yjs-binding/src/migrate.ts`)
-- [ ] T025 [US5] Round-trip test: representative scene (text+arrow `points`+image `fileId`+grouped+soft-deleted+`customData`+bound text/arrows) is deep-equal modulo the §6 normalization rules. (`packages/yjs-binding/tests/roundtrip.test.ts`) — SC-B-005
+- [X] T023 [US5] Implement `populateYDoc(sceneJSON, ydoc)`: write every element to the scene map (tombstones included), files to the files map; repair missing/invalid `index`. (`packages/yjs-binding/src/migrate.ts`) — data-model §6
+- [X] T024 [US5] Implement `exportSceneJSON(ydoc)`: read back to an Excalidraw scene (ordered by `index`). (`packages/yjs-binding/src/migrate.ts`)
+- [X] T025 [US5] Round-trip test: representative scene (text+arrow `points`+image `fileId`+grouped+soft-deleted+`customData`+bound text/arrows) is deep-equal modulo the §6 normalization rules. (`packages/yjs-binding/tests/roundtrip.test.ts`) — SC-B-005
 
 ---
 
 ## Phase 7: Convergence component tests + WS-F contribution (US1 — SC-B-001/002)
 
-- [ ] T026 [US1] Two-`Y.Doc` merge test: bindings A/B on one element; A sets position, B sets `strokeColor` while partitioned; exchange updates; assert both scenes carry both edits. (`packages/yjs-binding/tests/merge.test.ts`) — SC-B-001
-- [ ] T027 [P] [US1] Same-property tiebreak test: A and B set the same key differently; after sync both converge to one deterministic value, no divergence/exception. (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC2
-- [ ] T028 [P] [US1] Delete-vs-edit test: A tombstones an element while B edits a property; converge to a single consistent outcome (tombstone wins render, edit retained). (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC3
-- [ ] T029 [P] [US3] Concurrent order test: A and B insert elements that pick equal fractional `index`; `repairIndices` converges both to identical order. (`packages/yjs-binding/tests/apply-order.test.ts`) — US3-AC3
-- [ ] T030 Contribute the two-doc convergence + awareness-isolation scenarios to the shared WS-F e2e harness; ensure the package's coverage gate (≥95%) is wired into CI. (cross-repo: WS-F harness; `packages/yjs-binding` CI) — SC-B-006 / epic SC-008/SC-009
+- [X] T026 [US1] Two-`Y.Doc` merge test: bindings A/B on one element; A sets position, B sets `strokeColor` while partitioned; exchange updates; assert both scenes carry both edits. (`packages/yjs-binding/tests/merge.test.ts`) — SC-B-001
+- [X] T027 [P] [US1] Same-property tiebreak test: A and B set the same key differently; after sync both converge to one deterministic value, no divergence/exception. (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC2
+- [X] T028 [P] [US1] Delete-vs-edit test: A tombstones an element while B edits a property; converge to a single consistent outcome (tombstone wins render, edit retained). (`packages/yjs-binding/tests/merge.test.ts`) — US1-AC3
+- [X] T029 [P] [US3] Concurrent order test: A and B insert elements that pick equal fractional `index`; `repairIndices` converges both to identical order. (`packages/yjs-binding/tests/apply-order.test.ts`) — US3-AC3
+- [~] T030 Contribute the two-doc convergence + awareness-isolation scenarios to the shared WS-F e2e harness; ensure the package's coverage gate (≥95%) is wired into CI. (cross-repo: WS-F harness; `packages/yjs-binding` CI) — SC-B-006 / epic SC-008/SC-009
+  - **In-repo part DONE**: the two-doc convergence scenarios (`merge.test.ts`) and awareness-isolation scenario (`awareness.test.ts`) exist and pass; package coverage measured at **97.7% statements / 100% functions** (above the ≥95% gate) via `vitest run --coverage`.
+  - **Deferred (cross-repo)**: contributing these scenarios to the shared **WS-F** e2e harness and wiring the ≥95% threshold into the repo's CI workflow live outside this package and are owned by WS-F. Not done here.
 
 ---
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,9 @@
       "@excalidraw/math": ["./packages/math/src/index.ts"],
       "@excalidraw/math/*": ["./packages/math/src/*"],
       "@excalidraw/utils": ["./packages/utils/src/index.ts"],
-      "@excalidraw/utils/*": ["./packages/utils/src/*"]
+      "@excalidraw/utils/*": ["./packages/utils/src/*"],
+      "@alkemio/excalidraw-yjs-binding": ["./packages/yjs-binding/src/index.ts"],
+      "@alkemio/excalidraw-yjs-binding/*": ["./packages/yjs-binding/src/*"]
     }
   },
   "include": ["packages", "excalidraw-app"],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -59,6 +59,14 @@ export default defineConfig({
           "./packages/fractional-indexing/src/$1",
         ),
       },
+      {
+        find: /^@alkemio\/excalidraw-yjs-binding$/,
+        replacement: path.resolve(__dirname, "./packages/yjs-binding/src/index.ts"),
+      },
+      {
+        find: /^@alkemio\/excalidraw-yjs-binding\/(.*?)/,
+        replacement: path.resolve(__dirname, "./packages/yjs-binding/src/$1"),
+      },
     ],
   },
   //@ts-ignore

--- a/yarn.lock
+++ b/yarn.lock
@@ -7641,6 +7641,11 @@ isexe@^3.1.1:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
   integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
 
+isomorphic.js@^0.2.4:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.2.5.tgz#13eecf36f2dba53e85d355e11bf9d4208c6f7f88"
+  integrity sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==
+
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
@@ -7949,6 +7954,13 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+lib0@^0.2.85, lib0@^0.2.99:
+  version "0.2.117"
+  resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.117.tgz#6c3f926475d28904af05b590703cbbbc29475716"
+  integrity sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==
+  dependencies:
+    isomorphic.js "^0.2.4"
 
 lilconfig@2.0.4:
   version "2.0.4"
@@ -11152,6 +11164,13 @@ xmlhttprequest-ssl@~2.1.1:
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz#e9e8023b3f29ef34b97a859f584c5e6c61418e23"
   integrity sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==
 
+y-protocols@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/y-protocols/-/y-protocols-1.0.7.tgz#6631c492e75b78b3a61353a60067e6f8a4c38d5f"
+  integrity sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==
+  dependencies:
+    lib0 "^0.2.85"
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -11197,6 +11216,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yjs@^13.6.27:
+  version "13.6.31"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.6.31.tgz#3a9ddfe6d0c5d788521b70dfdd7b907148610418"
+  integrity sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==
+  dependencies:
+    lib0 "^0.2.99"
 
 zustand@^4.3.2:
   version "4.5.6"


### PR DESCRIPTION
## WS-B2 — Per-Property Yjs Whiteboard Binding

Stacked on top of #30 (B1 upstream-merge). **Base: `feat/003-unify-collab-yjs`.** Draft — do not merge.

Implements `specs/001-yjs-per-property-binding/` (tasks **T001–T029** done; **T030** partial — in-repo scenarios + coverage done, WS-F cross-repo harness deferred).

### What this adds
A new monorepo package **`packages/yjs-binding/`** that binds the live Excalidraw scene to a `Y.Doc` using a **per-property** CRDT model — replacing whole-element `version`/`versionNonce` LWW. Concurrent edits to *different* properties of one element both survive (the US1 win). Transport-agnostic: `yjs` + `y-protocols` only; no socket, no server, no v2 codec, no Go core.

### Design decisions (all 4 OPEN questions, exactly as resolved)
- **OPEN-1 HYBRID**: `boundElements` → nested `Y.Map<id,"arrow"|"text">` add/remove set (add-wins; lowest-id text resolution). `points`/`pressures`/`groupIds`/`roundness`/`startBinding`/`endBinding`/`fixedSegments`/`scale`/`crop`/`customData` → JSON-leaf. All else → scalar `Y.Map` values. Keys derived via `Object.keys`.
- **OPEN-2 allow-list**: `APPSTATE` `Y.Map` syncs **`viewBackgroundColor` + scene `name`** only.
- **OPEN-3 bump locally**: `version`/`versionNonce` recomputed on remote apply.
- **OPEN-4 defer GC**: tombstones never hard-deleted by the binding.

### Mechanics
- Echo prevention via `BINDING_ORIGIN` transaction sentinel + `observeDeep` guard.
- Per-property diff; a no-op `onChange` emits zero transactions.
- Order from the fractional `index` (pure `@excalidraw/fractional-indexing` + deterministic idempotent `repairIndices`).
- Apply: `updateScene({ captureUpdate: NEVER })`; preserves selection/zoom/scroll; APPSTATE allow-list; editing guard.
- Awareness/ephemeral routing never touches the scene doc.
- Lossless `populateYDoc`/`exportSceneJSON` round-trip.

### Tests — 65 vitest specs, two in-process `Y.Doc`s, no backend
US1 per-property convergence · boundElements set-merge · same-prop tiebreak · delete-vs-edit · echo/minimal-write · remote order + tombstone + equal-index repair · editing guard · awareness isolation · appState allow-list · migration round-trip.

### Gates
`tsc` clean · eslint `--max-warnings=0` clean · prettier `--check` clean · `vitest run` 65/65 · coverage 97.7% stmts / 100% funcs.

Out of scope: WS provider/server (WS-D/WS-C), client-web swap (WS-D), running the migration (WS-E), WS-F e2e harness.