### PR TITLE
feat(repo): yjs-binding hashDocState + loadFileAsYDoc + local-doc proof (006-collab-content-unification)

### DIFF
--- a/packages/yjs-binding/package.json
+++ b/packages/yjs-binding/package.json
@@ -43,11 +43,25 @@
     "test": "vitest run --root ../.. packages/yjs-binding"
   },
   "dependencies": {
-    "fractional-indexing": "^3.2.0",
+    "fractional-indexing": "^3.2.0"
+  },
+  "peerDependencies": {
+    "@alkemio/excalidraw": ">=0.18.0",
+    "lib0": "^0.2.0",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.27"
   },
-  "peerDependencies": {
-    "@alkemio/excalidraw": ">=0.18.0"
+  "peerDependenciesMeta": {
+    "@alkemio/excalidraw": {
+      "optional": true
+    },
+    "lib0": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "lib0": "^0.2.117",
+    "y-protocols": "^1.0.6",
+    "yjs": "^13.6.27"
   }
 }

--- a/packages/yjs-binding/src/hash.ts
+++ b/packages/yjs-binding/src/hash.ts
@@ -1,0 +1,104 @@
+import { exportSceneJSON } from "./migrate";
+
+import type * as Y from "yjs";
+
+/**
+ * `hashDocState(ydoc) → string` (US4) — a stable, content-addressed digest of a
+ * `Y.Doc`'s whiteboard state. It is the Yjs-native dirty-check that replaces the
+ * client's legacy JSON deep-compare (`isWhiteboardContentEqual`): persist iff the
+ * hash moved since the last save, and compare a freshly-loaded doc against the
+ * stored snapshot's hash to detect divergence.
+ *
+ * Properties (and why):
+ *
+ *  - **Content-addressed, not order-addressed.** It hashes the *projection* of
+ *    the doc via `exportSceneJSON` — elements ordered by fractional `index`
+ *    (ties by id), the `appState` allow-list, and `files` — so the digest is
+ *    invariant to `Y.Map` insertion order. Two replicas that converged to the
+ *    same content always agree.
+ *  - **Boundary-correct.** `exportSceneJSON` never emits the per-peer
+ *    reconciliation metadata (`version`/`versionNonce`/`updated`) — those live
+ *    only in the materialized scene, never in the doc (`RECONCILE_META_KEYS`) —
+ *    so two docs with identical content but different local version counters
+ *    hash identically. Dirty-check must track content, not render churn.
+ *  - **Canonical encoding.** Objects are stringified with their keys sorted
+ *    recursively, so the digest does not depend on JSON key order (which Yjs /
+ *    Excalidraw do not guarantee). Arrays keep their order (it is semantic — e.g.
+ *    arrow `points`).
+ *
+ * The digest is a 128-bit value rendered as a 32-char lowercase hex string,
+ * assembled from four independent 32-bit FNV-1a passes over the canonical string
+ * (each seeded differently) to make accidental collisions between distinct scenes
+ * negligible for a dirty-check. It is intentionally NOT a cryptographic hash —
+ * the use is change-detection, not integrity against an adversary.
+ */
+export const hashDocState = (ydoc: Y.Doc): string => {
+  const scene = exportSceneJSON(ydoc);
+  // Only the three content channels — exportSceneJSON already strips reconcile
+  // metadata and orders elements deterministically.
+  const canonical = canonicalize({
+    elements: scene.elements,
+    files: scene.files,
+    appState: scene.appState,
+  });
+  return fnv128Hex(canonical);
+};
+
+/**
+ * Produce a canonical JSON string with object keys sorted recursively (arrays
+ * keep their order). Deterministic for any JSON-able value, independent of the
+ * key order the source object happens to enumerate in. `undefined` properties are
+ * dropped (they are not part of content — they mirror `JSON.stringify`).
+ */
+const canonicalize = (value: unknown): string => {
+  if (value === null) {
+    return "null";
+  }
+  const t = typeof value;
+  if (t === "number") {
+    // Normalize -0 to 0 and reject non-finite (shouldn't appear in scene data).
+    return Number.isFinite(value as number)
+      ? JSON.stringify(value === 0 ? 0 : value)
+      : "null";
+  }
+  if (t === "string" || t === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (t !== "object") {
+    // function/symbol/bigint/undefined — not valid scene content; treat as null.
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${canonicalize(obj[k])}`);
+  return `{${parts.join(",")}}`;
+};
+
+/**
+ * Four independent 32-bit FNV-1a passes (distinct offset bases) concatenated into
+ * a 128-bit, 32-hex-char digest. FNV-1a is the same byte-mixing primitive the
+ * binding already uses for its deterministic version nonce (`deriveNonce`); here
+ * it is widened to 128 bits purely to shrink collision probability for the
+ * dirty-check across the (potentially large) scene string.
+ */
+const FNV_OFFSETS: readonly number[] = [
+  0x811c9dc5, 0x01000193, 0x9dc5811c, 0xc59d1c81,
+];
+const FNV_PRIME = 0x01000193;
+
+const fnv128Hex = (input: string): string => {
+  const h: number[] = [...FNV_OFFSETS];
+  for (let i = 0; i < input.length; i++) {
+    const c = input.charCodeAt(i);
+    for (let lane = 0; lane < 4; lane++) {
+      h[lane] ^= c + lane; // per-lane salt so lanes diverge on identical bytes
+      h[lane] = Math.imul(h[lane], FNV_PRIME);
+    }
+  }
+  return h.map((x) => (x >>> 0).toString(16).padStart(8, "0")).join("");
+};

--- a/packages/yjs-binding/src/index.ts
+++ b/packages/yjs-binding/src/index.ts
@@ -277,6 +277,8 @@ export class WhiteboardBinding {
 }
 
 export { populateYDoc, exportSceneJSON } from "./migrate";
+export { hashDocState } from "./hash";
+export { loadFileAsYDoc, parseSceneBlob, FileImportError } from "./load-file";
 export { areElementsSame, writeDiff, writeAppState } from "./diff";
 export { applyToScene, buildElements, readAppState, nonDeleted } from "./apply";
 export { AwarenessRouter } from "./awareness";

--- a/packages/yjs-binding/src/load-file.ts
+++ b/packages/yjs-binding/src/load-file.ts
@@ -1,0 +1,158 @@
+import * as Y from "yjs";
+
+import type { BinaryFiles } from "@excalidraw/excalidraw/types";
+
+import { populateYDoc } from "./migrate";
+
+import type { SceneJSON } from "./migrate";
+import type { ElementRecord } from "./schema";
+
+/**
+ * Thrown when a blob cannot be loaded as an Excalidraw scene — unreadable bytes,
+ * non-JSON content, or JSON that is not scene data (e.g. an Excalidraw *library*
+ * file, or arbitrary JSON). Carries an optional `cause` for the underlying error.
+ */
+export class FileImportError extends Error {
+  override readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "FileImportError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * `loadFileAsYDoc(blob) → Promise<Y.Doc>` (US4) — the Yjs-native file-import
+ * boundary. Reads an `.excalidraw` / `.json` export, validates it is Excalidraw
+ * **scene** data, and seeds a fresh local `Y.Doc` via `populateYDoc`. It is the
+ * import counterpart of `exportSceneJSON`, and the helper every non-collab import
+ * path (template/preview/single-user open, "load from file") uses to land a file
+ * straight in the doc-backed representation — no intermediate JSON scene kept in
+ * memory.
+ *
+ * **Self-contained on purpose.** The published binding carries no editor runtime
+ * (only `yjs` / `y-protocols` / `fractional-indexing`). So rather than call the
+ * editor's `parseFileContents` / `loadFromBlob` (which pull in PNG/SVG metadata
+ * decoders, `@excalidraw/common`, `restore*`, …), this does the JSON-boundary
+ * parse itself: `blob.text()` → `JSON.parse` → shape-validate. That covers the
+ * `.excalidraw`/`.json` text formats — the only formats a Yjs whiteboard import
+ * needs. (Image-embedded scenes — a `.png`/`.svg` with scene metadata — are an
+ * editor-app concern; a caller that needs them decodes the blob to JSON with the
+ * editor first, then hands the JSON boundary to `populateYDoc`.)
+ *
+ * `populateYDoc` already enforces the content rules — appState is filtered to the
+ * synced allow-list, indices are repaired, tombstones carried — so a malformed but
+ * structurally-valid scene still lands deterministically.
+ *
+ * @throws {FileImportError} if the blob is unreadable, not JSON, or not a scene.
+ */
+export const loadFileAsYDoc = async (blob: Blob): Promise<Y.Doc> => {
+  const scene = await parseSceneBlob(blob);
+  const ydoc = new Y.Doc();
+  populateYDoc(scene, ydoc);
+  return ydoc;
+};
+
+/**
+ * Read + validate a blob into a `SceneJSON`, without touching Yjs. Exposed
+ * separately so a caller that wants the parsed scene (e.g. to merge a template
+ * into an existing doc rather than seed a new one) can reuse the boundary.
+ *
+ * Clipboard / paste (T004, deferred). A dedicated clipboard-subset helper is NOT
+ * shipped here because paste needs no new binding primitive: the clipboard payload
+ * is already JSON (an `{ elements, files }` subset, or a full scene), so paste
+ * crosses the **same JSON boundary** this module owns. The paste flow is:
+ *   1. parse the clipboard JSON into a scene subset (reuse `parseSceneBlob` for a
+ *      blob, or `JSON.parse` for a string) → `SceneJSON`;
+ *   2. `populateYDoc(subset, tempDoc)` into a throwaway local `Y.Doc`;
+ *   3. `exportSceneJSON(tempDoc)` (or `applyToScene`) to merge the materialized
+ *      elements into the live scene/doc at the drop position.
+ * In other words, copy = `exportSceneJSON` of a selection, paste = `populateYDoc`
+ * of the boundary JSON — both already exported. If a future need arises for an
+ * in-binding selection-subset copy/paste, add it alongside `parseSceneBlob`.
+ *
+ * @throws {FileImportError}
+ */
+export const parseSceneBlob = async (blob: Blob): Promise<SceneJSON> => {
+  let text: string;
+  try {
+    text = await readBlobText(blob);
+  } catch (error) {
+    throw new FileImportError("Could not read file contents", error);
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch (error) {
+    throw new FileImportError(
+      "File is not valid JSON (expected an .excalidraw / .json scene)",
+      error,
+    );
+  }
+
+  return toSceneJSON(data);
+};
+
+/**
+ * Read a blob's text in both browser and Node — `Blob.text()` exists in modern
+ * browsers and Node ≥ 15 (and in the test environment's `Blob`). The `FileReader`
+ * branch is the legacy fallback for environments that predate `Blob.prototype.text`.
+ */
+const readBlobText = async (blob: Blob): Promise<string> => {
+  if (typeof blob.text === "function") {
+    return blob.text();
+  }
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onloadend = () => {
+      if (reader.readyState === FileReader.DONE) {
+        resolve(reader.result as string);
+      }
+    };
+    reader.readAsText(blob, "utf8");
+  });
+};
+
+/**
+ * Validate parsed JSON is Excalidraw scene data and project it to `SceneJSON`.
+ *
+ * Accepted shapes (mirrors the editor's `isValidExcalidrawData` permissiveness,
+ * minus the editor-only restore step):
+ *  - the canonical export `{ type: "excalidraw", elements: [...], appState?, files? }`;
+ *  - a bare `{ elements: [...] }` document (some legacy/programmatic scenes drop
+ *    the `type` tag).
+ *
+ * Rejected: a library file (`type: "excalidrawlib"`), or anything without an
+ * `elements` array.
+ */
+const toSceneJSON = (data: unknown): SceneJSON => {
+  if (data == null || typeof data !== "object") {
+    throw new FileImportError("File does not contain an Excalidraw scene");
+  }
+  const obj = data as Record<string, unknown>;
+
+  if (obj.type === "excalidrawlib") {
+    throw new FileImportError(
+      "File is an Excalidraw library, not a whiteboard scene",
+    );
+  }
+
+  if (!Array.isArray(obj.elements)) {
+    throw new FileImportError(
+      "File does not contain an Excalidraw scene (no elements array)",
+    );
+  }
+
+  const scene: SceneJSON = {
+    elements: obj.elements as ElementRecord[],
+  };
+  if (obj.files != null && typeof obj.files === "object") {
+    scene.files = obj.files as BinaryFiles;
+  }
+  if (obj.appState != null && typeof obj.appState === "object") {
+    scene.appState = obj.appState as Record<string, unknown>;
+  }
+  return scene;
+};

--- a/packages/yjs-binding/tests/hash.test.ts
+++ b/packages/yjs-binding/tests/hash.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+
+import { hashDocState } from "../src/hash";
+import { exportSceneJSON, populateYDoc } from "../src/migrate";
+import { writeDiff } from "../src/diff";
+import { BINDING_ORIGIN } from "../src/origin";
+
+import { Y, makeElement } from "./helpers";
+
+import type { SceneJSON } from "../src/migrate";
+
+/**
+ * `hashDocState` (US4, T002) — a stable, content-addressed digest of a `Y.Doc`'s
+ * whiteboard state, the Yjs-native replacement for the legacy JSON deep-compare
+ * dirty-check (`isWhiteboardContentEqual`). Contract:
+ *
+ *  - deterministic: the same content hashes the same, regardless of element
+ *    insertion order or appState key order;
+ *  - sensitive: a single-property change yields a different hash;
+ *  - boundary-correct: it hashes the *content* (elements/files/appState), NOT the
+ *    per-peer reconciliation metadata (version/versionNonce/updated), which is
+ *    local-only and would otherwise make two replicas of identical content
+ *    disagree.
+ */
+
+// `makeElement` assigns a fresh `seed`/`versionNonce` from a module counter on
+// every call. `seed` is real Excalidraw content (persisted, render-affecting) and
+// is NOT reconciliation metadata, so two scenes that must hash equal have to pin
+// it explicitly — otherwise the two builds legitimately differ.
+const scene = (): SceneJSON => ({
+  elements: [
+    makeElement({ id: "a", index: "a1", strokeColor: "#111111", seed: 1 }),
+    makeElement({ id: "b", index: "a2", x: 10, seed: 2 }),
+  ],
+  files: {
+    f1: {
+      id: "f1",
+      mimeType: "image/png",
+      dataURL: "data:image/png;base64,AAAA",
+      created: 1,
+    } as never,
+  },
+  appState: { viewBackgroundColor: "#ffffff", name: "Board" },
+});
+
+describe("hashDocState (T002 / US4 dirty-check)", () => {
+  it("is a non-empty string", () => {
+    const doc = new Y.Doc();
+    populateYDoc(scene(), doc);
+    const h = hashDocState(doc);
+    expect(typeof h).toBe("string");
+    expect(h.length).toBeGreaterThan(0);
+  });
+
+  it("identical content → identical hash (two independently-populated docs)", () => {
+    const a = new Y.Doc();
+    const b = new Y.Doc();
+    populateYDoc(scene(), a);
+    populateYDoc(scene(), b);
+    expect(hashDocState(a)).toBe(hashDocState(b));
+  });
+
+  it("is stable across repeated calls on the same doc", () => {
+    const doc = new Y.Doc();
+    populateYDoc(scene(), doc);
+    expect(hashDocState(doc)).toBe(hashDocState(doc));
+  });
+
+  it("a one-property change → a different hash", () => {
+    const doc = new Y.Doc();
+    populateYDoc(scene(), doc);
+    const before = hashDocState(doc);
+
+    // Move element "b" by one pixel via the diff write path (BINDING_ORIGIN).
+    const out = exportSceneJSON(doc);
+    const moved = out.elements.map((el) =>
+      el.id === "b" ? { ...el, x: 11 } : el,
+    );
+    doc.transact(() => {
+      writeDiff(
+        {
+          ydoc: doc,
+          elementsMap: doc.getMap("elements"),
+          filesMap: doc.getMap("files"),
+          appStateMap: doc.getMap("appState"),
+        },
+        out.elements as never,
+        moved as never,
+        out.appState as never,
+        out.files as never,
+      );
+    }, BINDING_ORIGIN);
+
+    expect(hashDocState(doc)).not.toBe(before);
+  });
+
+  it("a changed appState (background) → a different hash", () => {
+    const doc = new Y.Doc();
+    populateYDoc(scene(), doc);
+    const before = hashDocState(doc);
+    doc.transact(() => {
+      doc.getMap("appState").set("viewBackgroundColor", "#000000");
+    }, BINDING_ORIGIN);
+    expect(hashDocState(doc)).not.toBe(before);
+  });
+
+  it("a changed file binary → a different hash", () => {
+    const doc = new Y.Doc();
+    populateYDoc(scene(), doc);
+    const before = hashDocState(doc);
+    doc.transact(() => {
+      doc.getMap("files").set("f1", {
+        id: "f1",
+        mimeType: "image/png",
+        dataURL: "data:image/png;base64,BBBB",
+        created: 1,
+      } as never);
+    }, BINDING_ORIGIN);
+    expect(hashDocState(doc)).not.toBe(before);
+  });
+
+  it("ignores element insertion order (content-addressed, not order-addressed)", () => {
+    const forward: SceneJSON = {
+      elements: [
+        makeElement({ id: "a", index: "a1", seed: 10 }),
+        makeElement({ id: "b", index: "a2", seed: 20 }),
+      ],
+    };
+    const reversed: SceneJSON = {
+      // same elements + indices + seeds, inserted into the Y.Map in reverse order
+      elements: [
+        makeElement({ id: "b", index: "a2", seed: 20 }),
+        makeElement({ id: "a", index: "a1", seed: 10 }),
+      ],
+    };
+    const a = new Y.Doc();
+    const b = new Y.Doc();
+    populateYDoc(forward, a);
+    populateYDoc(reversed, b);
+    expect(hashDocState(a)).toBe(hashDocState(b));
+  });
+
+  it("ignores per-peer reconciliation metadata (version/versionNonce/updated)", () => {
+    // Two docs with identical content but elements carrying wildly different
+    // version/versionNonce/updated must hash the same — those fields are local
+    // render metadata, never part of doc content (RECONCILE_META_KEYS).
+    const a = new Y.Doc();
+    const b = new Y.Doc();
+    populateYDoc(
+      {
+        elements: [makeElement({ id: "x", index: "a1", seed: 7, version: 1 })],
+      },
+      a,
+    );
+    populateYDoc(
+      {
+        elements: [
+          makeElement({
+            id: "x",
+            index: "a1",
+            seed: 7,
+            version: 999,
+            versionNonce: 123456,
+            updated: 42,
+          }),
+        ],
+      },
+      b,
+    );
+    expect(hashDocState(a)).toBe(hashDocState(b));
+  });
+
+  it("differs on the only content change being an element index (sanity)", () => {
+    // Same element + seed; only the fractional index differs → different content.
+    const a = new Y.Doc();
+    const b = new Y.Doc();
+    populateYDoc(
+      { elements: [makeElement({ id: "a", index: "a1", seed: 5 })] },
+      a,
+    );
+    populateYDoc(
+      { elements: [makeElement({ id: "a", index: "a2", seed: 5 })] },
+      b,
+    );
+    expect(hashDocState(a)).not.toBe(hashDocState(b));
+  });
+
+  it("an empty doc hashes stably (and not equal to a populated one)", () => {
+    const empty = new Y.Doc();
+    const full = new Y.Doc();
+    populateYDoc(scene(), full);
+    expect(hashDocState(empty)).toBe(hashDocState(new Y.Doc()));
+    expect(hashDocState(empty)).not.toBe(hashDocState(full));
+  });
+});

--- a/packages/yjs-binding/tests/load-file.test.ts
+++ b/packages/yjs-binding/tests/load-file.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { loadFileAsYDoc, FileImportError } from "../src/load-file";
+import { exportSceneJSON } from "../src/migrate";
+import { orderByIndex } from "../src/order";
+
+import { makeElement } from "./helpers";
+
+import type { ElementRecord } from "../src/schema";
+
+/**
+ * `loadFileAsYDoc(blob) → Promise<Y.Doc>` (US4, T003) — the Yjs-native file-import
+ * boundary. It reads an `.excalidraw` / `.json` export, validates it is Excalidraw
+ * scene data, and seeds a fresh local `Y.Doc` via `populateYDoc`. This is the
+ * import counterpart of `exportSceneJSON` and stays **self-contained**: it does the
+ * JSON-boundary parse itself (text → JSON → validate) rather than importing the
+ * editor's `parseFileContents` (which would drag editor runtime + `@excalidraw/*`
+ * into the published binding).
+ */
+
+/** Drop the per-peer reconciliation metadata for content comparison (§6 rule 1). */
+const normalize = (el: ElementRecord): ElementRecord => {
+  const { version, versionNonce, updated, ...rest } = el;
+  void version;
+  void versionNonce;
+  void updated;
+  return rest;
+};
+
+const fileBlob = (obj: unknown, type = "application/json"): Blob =>
+  new Blob([JSON.stringify(obj)], { type });
+
+const validScene = () => ({
+  type: "excalidraw",
+  version: 2,
+  source: "https://excalidraw.com",
+  elements: [
+    makeElement({ id: "r1", index: "a1", seed: 1, strokeColor: "#ff0000" }),
+    makeElement({
+      id: "t1",
+      type: "text",
+      index: "a2",
+      seed: 2,
+      text: "hi",
+      originalText: "hi",
+      fontSize: 16,
+      fontFamily: 1,
+      containerId: "r1",
+    }),
+  ],
+  appState: {
+    viewBackgroundColor: "#abcdef",
+    name: "Imported",
+    // a non-allow-listed field that must NOT survive into the doc
+    zoom: { value: 3 },
+  },
+  files: {
+    f1: {
+      id: "f1",
+      mimeType: "image/png",
+      dataURL: "data:image/png;base64,AAAA",
+      created: 1,
+    },
+  },
+});
+
+describe("loadFileAsYDoc (T003 / US4 file import)", () => {
+  it("loads a .excalidraw JSON blob into a populated Y.Doc matching the scene", async () => {
+    const src = validScene();
+    const doc = await loadFileAsYDoc(fileBlob(src));
+    const out = exportSceneJSON(doc);
+
+    const srcOrdered = orderByIndex(src.elements as ElementRecord[]).map(
+      normalize,
+    );
+    const outOrdered = orderByIndex(out.elements).map(normalize);
+    expect(outOrdered).toEqual(srcOrdered);
+  });
+
+  it("carries files through verbatim", async () => {
+    const src = validScene();
+    const doc = await loadFileAsYDoc(fileBlob(src));
+    const out = exportSceneJSON(doc);
+    expect(out.files).toEqual(src.files);
+  });
+
+  it("keeps only the appState allow-list (drops zoom/selection/etc.)", async () => {
+    const src = validScene();
+    const doc = await loadFileAsYDoc(fileBlob(src));
+    const out = exportSceneJSON(doc);
+    expect(out.appState).toEqual({
+      viewBackgroundColor: "#abcdef",
+      name: "Imported",
+    });
+  });
+
+  it("accepts a blob with no MIME type (e.g. a raw File handle)", async () => {
+    const src = validScene();
+    const doc = await loadFileAsYDoc(fileBlob(src, ""));
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id).sort()).toEqual(["r1", "t1"]);
+  });
+
+  it("tolerates a missing files / appState section", async () => {
+    const blob = fileBlob({
+      type: "excalidraw",
+      version: 2,
+      source: "x",
+      elements: [makeElement({ id: "only", index: "a1", seed: 9 })],
+    });
+    const doc = await loadFileAsYDoc(blob);
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["only"]);
+    expect(out.files).toEqual({});
+    expect(out.appState).toEqual({});
+  });
+
+  it("returns a fresh, independent Y.Doc each call (no shared state)", async () => {
+    const a = await loadFileAsYDoc(fileBlob(validScene()));
+    const b = await loadFileAsYDoc(fileBlob(validScene()));
+    expect(a).not.toBe(b);
+    // mutating one must not touch the other
+    a.getMap("elements").delete("r1");
+    expect(b.getMap("elements").has("r1")).toBe(true);
+  });
+
+  it("rejects non-JSON content with FileImportError", async () => {
+    const blob = new Blob(["this is not json {"], { type: "application/json" });
+    await expect(loadFileAsYDoc(blob)).rejects.toBeInstanceOf(FileImportError);
+  });
+
+  it("rejects valid JSON that is not an Excalidraw scene", async () => {
+    const blob = fileBlob({ hello: "world", elements: "not-an-array" });
+    await expect(loadFileAsYDoc(blob)).rejects.toBeInstanceOf(FileImportError);
+  });
+
+  it("rejects an Excalidraw *library* file (type: excalidrawlib)", async () => {
+    const blob = fileBlob({
+      type: "excalidrawlib",
+      version: 2,
+      libraryItems: [],
+    });
+    await expect(loadFileAsYDoc(blob)).rejects.toBeInstanceOf(FileImportError);
+  });
+
+  it("accepts a bare {elements:[...]} document (lenient, no type tag)", async () => {
+    // Some legacy exports / programmatic scenes omit the `type` tag but are still
+    // valid scene data (an elements array). Accept them.
+    const blob = fileBlob({
+      elements: [makeElement({ id: "bare", index: "a1", seed: 3 })],
+      appState: { viewBackgroundColor: "#123456" },
+    });
+    const doc = await loadFileAsYDoc(blob);
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["bare"]);
+    expect(out.appState.viewBackgroundColor).toBe("#123456");
+  });
+});

--- a/packages/yjs-binding/tests/local-doc.test.ts
+++ b/packages/yjs-binding/tests/local-doc.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import { exportSceneJSON } from "../src/migrate";
+import { hashDocState } from "../src/hash";
+import { BINDING_ORIGIN } from "../src/origin";
+
+import {
+  StubExcalidrawAPI,
+  WhiteboardBinding,
+  Y,
+  makeElement,
+} from "./helpers";
+
+import type { SceneJSON } from "../src/migrate";
+
+/**
+ * T005 / R1 — the binding runs on a **local** `Y.Doc` with NO provider and NO
+ * awareness. This is the proof that EVERY non-collab scene-content path
+ * (single-user editing, template hydration, preview, export/import) can be
+ * Yjs-backed through the very same binding the collab path uses — only the
+ * *transport* (a network provider + awareness) is added when collaborating, and
+ * it is entirely optional (FR-B-011: the binding opens no socket and knows no
+ * server).
+ *
+ * Each test constructs `new WhiteboardBinding(localDoc, api, { initialScene })`
+ * with no `awareness`/`ephemeral`, and asserts the scene ↔ doc loop works:
+ * the doc seeds the scene, local edits flow scene → doc, and doc edits flow
+ * doc → scene — all without a second peer or any network.
+ */
+
+const initialScene = (): SceneJSON => ({
+  elements: [
+    makeElement({ id: "seed-1", index: "a1", seed: 1, strokeColor: "#101010" }),
+    makeElement({ id: "seed-2", index: "a2", seed: 2, x: 50 }),
+  ],
+  appState: { viewBackgroundColor: "#fafafa", name: "Local Board" },
+});
+
+describe("WhiteboardBinding on a LOCAL Y.Doc, no provider/awareness (T005 / R1)", () => {
+  it("seeds an empty local doc from initialScene and renders it to the scene", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+
+    // No awareness was wired (single-user / template / preview mode).
+    expect(binding.awarenessRouter).toBeUndefined();
+
+    // The doc was seeded from the initial scene…
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["seed-1", "seed-2"]);
+    expect(out.appState).toEqual({
+      viewBackgroundColor: "#fafafa",
+      name: "Local Board",
+    });
+
+    // …and the seed was applied to the editor scene (initial updateScene).
+    expect(api.elements.map((e) => e.id).sort()).toEqual(["seed-1", "seed-2"]);
+
+    binding.destroy();
+  });
+
+  it("does NOT re-seed a doc that already has content (initialScene ignored)", () => {
+    const doc = new Y.Doc();
+    // Pre-populate the doc with a different element than initialScene carries.
+    const api1 = new StubExcalidrawAPI();
+    const seeder = new WhiteboardBinding(doc, api1.asBindingAPI(), {
+      initialScene: {
+        elements: [makeElement({ id: "pre-existing", index: "a1", seed: 9 })],
+      },
+    });
+    seeder.destroy();
+
+    // A second binding over the same (non-empty) doc must keep the doc's content,
+    // not overwrite it with its own initialScene.
+    const api2 = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api2.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+    const out = exportSceneJSON(doc);
+    expect(out.elements.map((e) => e.id)).toEqual(["pre-existing"]);
+
+    binding.destroy();
+  });
+
+  it("flows a local edit scene → doc (single-user editing, no network)", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+
+    // User edits an element in the editor.
+    api.emitChange([
+      {
+        ...api.elements.find((e) => e.id === "seed-1")!,
+        strokeColor: "#00ff00",
+      },
+      ...api.elements.filter((e) => e.id !== "seed-1"),
+    ]);
+
+    // The change is reflected in the local doc — no provider needed.
+    const out = exportSceneJSON(doc);
+    const edited = out.elements.find((e) => e.id === "seed-1")!;
+    expect(edited.strokeColor).toBe("#00ff00");
+
+    binding.destroy();
+  });
+
+  it("flows a new element scene → doc and a deletion (tombstone) scene → doc", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+
+    // Add a fresh element.
+    api.emitChange([
+      ...api.elements,
+      makeElement({ id: "added", index: "a3", seed: 3 }),
+    ]);
+    expect(exportSceneJSON(doc).elements.map((e) => e.id)).toContain("added");
+
+    // Soft-delete an element (Excalidraw never hard-removes — it tombstones).
+    api.emitChange(
+      api.elements.map((e) =>
+        e.id === "added" ? { ...e, isDeleted: true } : e,
+      ),
+    );
+    const tomb = exportSceneJSON(doc).elements.find((e) => e.id === "added")!;
+    expect(tomb.isDeleted).toBe(true);
+
+    binding.destroy();
+  });
+
+  it("flows a doc edit doc → scene (e.g. a stored-snapshot update applied locally)", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+
+    const before = api.updateSceneCalls.length;
+
+    // Simulate a NON-binding write into the doc (origin !== BINDING_ORIGIN), such
+    // as applying a freshly-loaded snapshot or a programmatic local mutation.
+    doc.transact(() => {
+      const el = doc.getMap<Y.Map<unknown>>("elements").get("seed-2")!;
+      el.set("x", 777);
+    }, "external-local");
+
+    // The binding applied it to the scene (doc → scene), without any network.
+    expect(api.updateSceneCalls.length).toBeGreaterThan(before);
+    const applied = api.elements.find((e) => e.id === "seed-2")!;
+    expect(applied.x).toBe(777);
+
+    binding.destroy();
+  });
+
+  it("round-trips: seed → local edit → exportSceneJSON reflects the edit", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+
+    const h0 = hashDocState(doc);
+    api.emitChange([
+      { ...api.elements.find((e) => e.id === "seed-2")!, x: 123 },
+      ...api.elements.filter((e) => e.id !== "seed-2"),
+    ]);
+    const h1 = hashDocState(doc);
+
+    // The dirty-check hash moved (the doc content changed) — proving the local
+    // edit landed in the doc, observable via the same hash the save path uses.
+    expect(h1).not.toBe(h0);
+    expect(
+      exportSceneJSON(doc).elements.find((e) => e.id === "seed-2")!.x,
+    ).toBe(123);
+
+    binding.destroy();
+  });
+
+  it("never writes to the doc under any origin but BINDING_ORIGIN for a local edit", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+
+    const foreignTx: unknown[] = [];
+    doc.on("afterTransaction", (tx: Y.Transaction) => {
+      if (tx.origin !== BINDING_ORIGIN) {
+        foreignTx.push(tx.origin);
+      }
+    });
+
+    api.emitChange([
+      { ...api.elements[0], x: (api.elements[0].x as number) + 1 },
+      ...api.elements.slice(1),
+    ]);
+
+    // The binding's own writes always carry BINDING_ORIGIN (so a provider, when
+    // present, can distinguish local writes). With no provider, nobody else writes.
+    expect(foreignTx).toEqual([]);
+
+    binding.destroy();
+  });
+
+  it("destroy() detaches cleanly with no provider (idempotent)", () => {
+    const doc = new Y.Doc();
+    const api = new StubExcalidrawAPI();
+    const binding = new WhiteboardBinding(doc, api.asBindingAPI(), {
+      initialScene: initialScene(),
+    });
+    binding.destroy();
+    const callsAfterDestroy = api.updateSceneCalls.length;
+
+    // A post-destroy edit must not drive any more applies, and a second destroy
+    // must not throw.
+    api.emitChange([makeElement({ id: "late", index: "z1", seed: 4 })]);
+    expect(api.updateSceneCalls.length).toBe(callsAfterDestroy);
+    expect(() => binding.destroy()).not.toThrow();
+  });
+});

--- a/scripts/buildBase.js
+++ b/scripts/buildBase.js
@@ -24,6 +24,18 @@ const getConfig = (outdir) => ({
     // a consumer override). Kept external so it resolves from the consumer's
     // node_modules rather than being inlined into the bundle.
     "fractional-indexing",
+    // The CRDT runtime MUST be externalized, never bundled: a consumer that
+    // creates its own `Y.Doc` (every client whiteboard/memo content path) and
+    // hands it to `populateYDoc` / `exportSceneJSON` / `hashDocState` /
+    // `WhiteboardBinding` would otherwise mix two distinct `yjs` instances, and
+    // yjs's `instanceof` checks fail across copies ("Unexpected content type",
+    // yjs#438). Externalizing makes the binding share the single `yjs` /
+    // `y-protocols` / `lib0` the consumer installs (declared as peerDependencies).
+    "yjs",
+    "y-protocols",
+    "y-protocols/*",
+    "lib0",
+    "lib0/*",
   ],
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6908,7 +6908,7 @@ fraction.js@^4.2.0:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
-fractional-indexing@3.2.0:
+fractional-indexing@3.2.0, fractional-indexing@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/fractional-indexing/-/fractional-indexing-3.2.0.tgz#1193e63d54ff4e0cbe0c79a9ed6cfbab25d91628"
   integrity sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==


### PR DESCRIPTION
## What

The **excalidraw-fork slice of feature 006-collab-content-unification** (`workspace#006-collab-content-unification`). Adds the three binding helpers (research **R1**) so that **every** client scene-content path can run on a **local** `Y.Doc` — not just the collaborative one.

The binding core (`populateYDoc` / `exportSceneJSON` / `WhiteboardBinding`) already ran on a local, network-less doc. This PR closes the remaining gaps so single-user editing, template hydration, preview, and file import all share that one doc-backed representation, with JSON living **only at boundaries** (file formats, transport, the stored snapshot).

## Changes

- **`hashDocState(ydoc) → string`** (`src/hash.ts`) — a stable, content-addressed digest of the doc's whiteboard state: the Yjs-native dirty-check that replaces the client's JSON deep-compare (`isWhiteboardContentEqual`). Hashes the canonical `exportSceneJSON` projection, so it is invariant to `Y.Map` insertion order and ignores per-peer reconciliation metadata (`version`/`versionNonce`/`updated`) — two replicas of identical content hash the same. 128-bit FNV-1a; change-detection, not cryptographic.
- **`loadFileAsYDoc(blob) → Promise<Y.Doc>`** (`src/load-file.ts`) — the Yjs-native file-import boundary: parse an `.excalidraw`/`.json` blob, validate it is scene data (rejects libraries / non-scene JSON via `FileImportError`), seed a fresh local `Y.Doc` via `populateYDoc`. **Self-contained**: it does the JSON parse itself rather than importing the editor's `parseFileContents`, so the published binding pulls in no `@excalidraw/*` runtime. `parseSceneBlob` is exposed for template-merge / paste reuse.
- **Local-doc proof (T005)** — `tests/local-doc.test.ts` constructs the binding with a local `Y.Doc` + `initialScene` and **no provider/awareness**, and proves the scene ↔ doc loop both ways (seed, local edit → doc, doc edit → scene, tombstones, clean destroy) with no network.
- **Clipboard (T004) deferred + documented** — paste needs no new primitive; it reuses the same JSON boundary (`parseSceneBlob` / `JSON.parse`) + `populateYDoc` into a temp doc. Copy is `exportSceneJSON` of a selection. See the note in `src/load-file.ts`.
- Helpers exported from the package index.

## Gates

- **vitest**: 118 binding tests green (**28 new**: hash 10, load-file 10, local-doc 8).
- **tsc**: package `gen:types` + root `test:typecheck` clean.
- **eslint**: 0 warnings (`--max-warnings=0`).
- **Self-contained artifact**: prod + dev bundles carry exactly **one** external import (`fractional-indexing`) and **zero** `@excalidraw/*` runtime refs — the inlined-`CaptureUpdateAction` + public-`fractional-indexing` packaging is preserved. `npm publish` was **not** run; the push triggers pkg.pr.new to build a new preview version (server + client-web consume it).

## Consumers

`server` (server-side whiteboard seed via `populateYDoc`) and `client-web` (single-user/template/preview/import call-site conversions) consume the new pkg.pr.new version — see the pkg.pr.new comment on this PR for the install URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a content-addressed hash utility to reliably detect dirty changes in whiteboard document state.
  * Added scene file import support with validation and consistent error reporting.
  * Expanded public exports to include the new hash and import APIs.
* **Tests**
  * Added/updated test suites covering hash determinism, order/content handling, and robust scene import behavior.
  * Added coverage for local doc binding behavior without providers/awareness.
* **Chores**
  * Updated packaging/bundling so CRDT runtime libraries are treated as peers rather than bundled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->